### PR TITLE
Feature/#55 avoid unwrap expect

### DIFF
--- a/backend/src/config/db.rs
+++ b/backend/src/config/db.rs
@@ -9,8 +9,7 @@ pub type Pool = r2d2::Pool<ConnectionManager<Connection>>;
 #[allow(clippy::expect_used)]
 pub fn config(url: &str) -> Pool {
     let manager = ConnectionManager::<Connection>::new(url);
-    let pool = r2d2::Pool::builder()
+    r2d2::Pool::builder()
         .build(manager)
-        .expect("Failed to create pool.");
-    pool
+        .expect("Failed to create pool.")
 }

--- a/backend/src/config/db.rs
+++ b/backend/src/config/db.rs
@@ -6,9 +6,12 @@ use diesel::{
 pub type Connection = PgConnection;
 pub type Pool = r2d2::Pool<ConnectionManager<Connection>>;
 
-#[allow(clippy::expect_used)]
 pub fn config(url: &str) -> Pool {
     let manager = ConnectionManager::<Connection>::new(url);
+
+    // Panics if the connection to the database could not be established after a certain period of time.
+    // Since http calls would fail without a database connection it is irrecoverable.
+    #[allow(clippy::expect_used)]
     r2d2::Pool::builder()
         .build(manager)
         .expect("Failed to create pool.")

--- a/backend/src/config/db.rs
+++ b/backend/src/config/db.rs
@@ -6,6 +6,7 @@ use diesel::{
 pub type Connection = PgConnection;
 pub type Pool = r2d2::Pool<ConnectionManager<Connection>>;
 
+#[allow(clippy::expect_used)]
 pub fn config(url: &str) -> Pool {
     let manager = ConnectionManager::<Connection>::new(url);
     let pool = r2d2::Pool::builder()

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -21,3 +21,9 @@ impl ServiceError {
         HttpResponse::build(self.http_status).json(&self.body)
     }
 }
+
+impl From<diesel::r2d2::PoolError> for ServiceError {
+    fn from(value: diesel::r2d2::PoolError) -> Self {
+        Self::new(StatusCode::INTERNAL_SERVER_ERROR, value.to_string())
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,4 +1,6 @@
 #![recursion_limit = "256"]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
 
 use dotenvy::dotenv;
 

--- a/backend/src/models/dto/new_seed_dto.rs
+++ b/backend/src/models/dto/new_seed_dto.rs
@@ -31,7 +31,7 @@ impl From<NewSeedDTO> for NewSeed {
             variety_id: new_seed.variety_id,
             harvest_year: new_seed.harvest_year,
             quantity: new_seed.quantity,
-            tags: new_seed.tags.into_iter().map(|tag| Some(tag)).collect(),
+            tags: new_seed.tags.into_iter().map(Some).collect(),
             use_by: new_seed.use_by,
             origin: new_seed.origin,
             taste: new_seed.taste,

--- a/backend/src/models/seed.rs
+++ b/backend/src/models/seed.rs
@@ -50,7 +50,7 @@ pub struct NewSeed {
 impl Seed {
     pub fn find_all(conn: &mut Connection) -> QueryResult<Vec<SeedDTO>> {
         let query_result = seeds::table.select(all_columns).load::<Seed>(conn);
-        return query_result.map(|v| v.into_iter().map(|v| v.into()).collect());
+        query_result.map(|v| v.into_iter().map(|v| v.into()).collect())
     }
 
     pub fn create(new_seed: NewSeedDTO, conn: &mut Connection) -> QueryResult<SeedDTO> {
@@ -58,7 +58,7 @@ impl Seed {
         let query_result = diesel::insert_into(seeds::table)
             .values(&new_seed)
             .get_result(conn);
-        return query_result.map(|v: Seed| v.into());
+        query_result.map(|v: Seed| v.into())
     }
 
     pub fn delete_by_id(id: i32, conn: &mut Connection) -> QueryResult<usize> {

--- a/backend/src/models/variety.rs
+++ b/backend/src/models/variety.rs
@@ -17,6 +17,6 @@ pub struct Variety {
 impl Variety {
     pub fn find_all(conn: &mut Connection) -> QueryResult<Vec<VarietyDTO>> {
         let query_result = varieties::table.select(all_columns).load::<Variety>(conn);
-        return query_result.map(|v| v.into_iter().map(|v| v.into()).collect());
+        query_result.map(|v| v.into_iter().map(|v| v.into()).collect())
     }
 }

--- a/backend/src/services/seed_service.rs
+++ b/backend/src/services/seed_service.rs
@@ -9,9 +9,9 @@ use crate::{
     },
 };
 
-#[allow(clippy::expect_used)]
 pub fn find_all(pool: &Data<Pool>) -> Result<Vec<SeedDTO>, ServiceError> {
-    let mut conn = pool.get().expect("Failed to retrieve pool.");
+    let mut conn = pool.get()?;
+
     match Seed::find_all(&mut conn) {
         Ok(seeds) => Ok(seeds),
         Err(msg) => Err(ServiceError::new(
@@ -21,9 +21,9 @@ pub fn find_all(pool: &Data<Pool>) -> Result<Vec<SeedDTO>, ServiceError> {
     }
 }
 
-#[allow(clippy::expect_used)]
 pub fn create(new_seed: NewSeedDTO, pool: &Data<Pool>) -> Result<SeedDTO, ServiceError> {
-    let mut conn = pool.get().expect("Failed to retrieve pool.");
+    let mut conn = pool.get()?;
+
     match Seed::create(new_seed, &mut conn) {
         Ok(seed) => Ok(seed),
         Err(msg) => Err(ServiceError::new(
@@ -33,9 +33,9 @@ pub fn create(new_seed: NewSeedDTO, pool: &Data<Pool>) -> Result<SeedDTO, Servic
     }
 }
 
-#[allow(clippy::expect_used)]
 pub fn delete_by_id(id: i32, pool: &Data<Pool>) -> Result<(), ServiceError> {
-    let mut conn = pool.get().expect("Failed to retrieve pool.");
+    let mut conn = pool.get()?;
+
     match Seed::delete_by_id(id, &mut conn) {
         Ok(_) => Ok(()),
         Err(msg) => Err(ServiceError::new(

--- a/backend/src/services/seed_service.rs
+++ b/backend/src/services/seed_service.rs
@@ -9,6 +9,7 @@ use crate::{
     },
 };
 
+#[allow(clippy::expect_used)]
 pub fn find_all(pool: &Data<Pool>) -> Result<Vec<SeedDTO>, ServiceError> {
     let mut conn = pool.get().expect("Failed to retrieve pool.");
     match Seed::find_all(&mut conn) {
@@ -20,6 +21,7 @@ pub fn find_all(pool: &Data<Pool>) -> Result<Vec<SeedDTO>, ServiceError> {
     }
 }
 
+#[allow(clippy::expect_used)]
 pub fn create(new_seed: NewSeedDTO, pool: &Data<Pool>) -> Result<SeedDTO, ServiceError> {
     let mut conn = pool.get().expect("Failed to retrieve pool.");
     match Seed::create(new_seed, &mut conn) {
@@ -31,6 +33,7 @@ pub fn create(new_seed: NewSeedDTO, pool: &Data<Pool>) -> Result<SeedDTO, Servic
     }
 }
 
+#[allow(clippy::expect_used)]
 pub fn delete_by_id(id: i32, pool: &Data<Pool>) -> Result<(), ServiceError> {
     let mut conn = pool.get().expect("Failed to retrieve pool.");
     match Seed::delete_by_id(id, &mut conn) {

--- a/backend/src/services/variety_service.rs
+++ b/backend/src/services/variety_service.rs
@@ -6,6 +6,7 @@ use crate::{
     models::{dto::variety_dto::VarietyDTO, variety::Variety},
 };
 
+#[allow(clippy::expect_used)]
 pub fn find_all(pool: &Data<Pool>) -> Result<Vec<VarietyDTO>, ServiceError> {
     let mut conn = pool.get().expect("Failed to retrieve pool.");
     match Variety::find_all(&mut conn) {

--- a/backend/src/services/variety_service.rs
+++ b/backend/src/services/variety_service.rs
@@ -6,9 +6,9 @@ use crate::{
     models::{dto::variety_dto::VarietyDTO, variety::Variety},
 };
 
-#[allow(clippy::expect_used)]
 pub fn find_all(pool: &Data<Pool>) -> Result<Vec<VarietyDTO>, ServiceError> {
-    let mut conn = pool.get().expect("Failed to retrieve pool.");
+    let mut conn = pool.get()?;
+
     match Variety::find_all(&mut conn) {
         Ok(varieties) => Ok(varieties),
         Err(msg) => Err(ServiceError::new(


### PR DESCRIPTION
Deny expect and unwrap like discussed in #55. For now allow already existing expect. Depending on whether those can actually fail we might later on remove those as well.

Fix other clippy warnings as well as they would be quite annoying when adding a clippy check to ci.