### PR TITLE
Dissalow negative numbers in generation field.

### DIFF
--- a/frontend/src/components/Form/SimpleFormInput.tsx
+++ b/frontend/src/components/Form/SimpleFormInput.tsx
@@ -9,6 +9,8 @@ interface SimpleFormInputProps<T extends FieldValues> {
   isArea?: boolean;
   required?: boolean;
   type?: HTMLInputTypeAttribute;
+  min?: number;
+  max?: number;
   register?: UseFormRegister<T>;
   valueAsNumber?: boolean;
   errorTitle?: string;
@@ -20,6 +22,8 @@ export default function SimpleFormInput<T extends FieldValues>({
   required = false,
   isArea = false,
   type = 'text',
+  min,
+  max,
   id,
   register,
   valueAsNumber = false,
@@ -44,6 +48,8 @@ export default function SimpleFormInput<T extends FieldValues>({
       ) : (
         <input
           type={type}
+          min={min}
+          max={max}
           id={id}
           className="block h-11 w-full rounded-lg border border-zinc-800 bg-primary-textfield p-2.5 text-sm text-white placeholder-neutral-700 focus:border-gray-600 focus:outline-none"
           placeholder={placeHolder}

--- a/frontend/src/features/seeds/components/CreateSeedForm.tsx
+++ b/frontend/src/features/seeds/components/CreateSeedForm.tsx
@@ -142,6 +142,7 @@ const CreateSeedForm = ({ onCancel, onSubmit }: CreateSeedFormProps) => {
           />
           <SimpleFormInput
             type="number"
+            min={0}
             labelText="Generation"
             placeHolder="0"
             id="generation"


### PR DESCRIPTION
As mentioned in #35, a plants generation should not be a negative number.
For this purpose, I added min and max attributes to SimpleFormInput and applied them to the relevant input field on the seed entry page.