### PR TITLE
docs: add links for frontend contribution

### DIFF
--- a/doc/contrib/frontend.md
+++ b/doc/contrib/frontend.md
@@ -72,3 +72,15 @@ import {MyComponent} from "@/features/my-feature/components/MyComponent
 ```
 
 Think of a feature as a library or a module that is self-contained but can expose different parts to other features via its entry point.
+
+## Helpful Links
+
+React:
+
+- [The new React documentation (as of 16.03.2023)](https://react.dev/learn)
+- [Advanced and detailed blog](https://kentcdodds.com/blog?q=react)
+
+Zustand (Global State Management):
+
+- [Tutorial](https://blog.logrocket.com/managing-react-state-zustand/)
+- [The Zustand documentation](https://github.com/pmndrs/zustand)


### PR DESCRIPTION
<!--
Check relevant points but **please do not remove entries**.
-->

As mentioned in [#43](https://github.com/ElektraInitiative/PermaplanT/issues/43) I would like to add some links to useful tutorials to the contribution page.

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [x] Details of what you changed are in commit messages
      (first line should have `module: short statement` syntax)
- [ ] References to issues, e.g. `close #X`, are in the commit messages.
- [x] The buildserver is happy.
- [x] The PR is rebased with current master.

<!--
If you have any troubles fulfilling these criteria, please write about the trouble as comment in the PR.
We will help you, but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For documentation fixes, spell checking, and similar none of these points below need to be checked.
-->

- [ ] I added unit tests for my code
- [ ] I fully described what my PR does in the documentation
      (not in the PR description)
- [ ] I fixed all affected documentation
- [ ] I fixed all affected decisions
- [ ] I added code comments, logging, and assertions as appropriate
- [ ] I mentioned [every code](/.reuse/dep5) not directly written by me in [reuse syntax](https://reuse.software/)


## Review

<!--
Reviewers should check the following.
-->

- [ ] Documentation is conforming to [our Documentation Guidelines](/doc/documentation.md)
- [ ] Examples are well chosen and understandable
- [ ] Code is conforming to our Coding Guidelines
- [ ] Code is consistent to [our Design Decisions](/doc/decisions)
