### PR TITLE
Polyculture Use Case: Incomplete Groups

### DIFF
--- a/doc/usecases/polyculture/incomplete_groups.md
+++ b/doc/usecases/polyculture/incomplete_groups.md
@@ -1,0 +1,24 @@
+# Use Case: Incomplete Groups
+
+## Summary
+
+- **Scope:** Plants Layer
+- **Level:** User Goal
+- **Actors:** App User
+- **Brief:** The user is informed about what plant groups need more planning.
+- **Status:** Draft
+
+## Scenarios
+
+- **Precondition:**
+  - The user has opened the app
+  - The plants layer is visible
+  - At least one plant is placed
+  - At least one of the placed plants is in need of another companion plant.
+- **Main success scenario:**
+  - Groups which need more companions are visually highlighted.
+- **Alternative scenario:**
+- **Error scenario:**
+- **Postcondition:**
+  - The user knows which groups need more attention.
+- **Non-functional Constraints:**

--- a/doc/usecases/polyculture/incomplete_groups.md
+++ b/doc/usecases/polyculture/incomplete_groups.md
@@ -15,10 +15,12 @@
   - The user has opened the app
   - The plants layer is visible
   - At least one plant is placed
-  - At least one of the placed plants is in need of another companion plant.
+  - At least to one of the placed plants a companion plant can be added.
 - **Main success scenario:**
-  - Groups which need more companions are visually highlighted.
+  - Groups, where further companions are available, are visually highlighted.
 - **Alternative scenario:**
+  - No groups have further companions available.
+    This is visually indicated.
 - **Error scenario:**
 - **Postcondition:**
   - The user knows which groups need more attention.

--- a/doc/usecases/polyculture/incomplete_groups.md
+++ b/doc/usecases/polyculture/incomplete_groups.md
@@ -6,7 +6,8 @@
 - **Level:** User Goal
 - **Actors:** App User
 - **Brief:** The user is informed about what plant groups need more planning.
-- **Status:** Draft
+- **Status:** Assigned
+- **Assignee:** Benjamin
 
 ## Scenarios
 


### PR DESCRIPTION
This should document the following use case from https://github.com/ElektraInitiative/PermaplanT/issues/1
> incomplete groups: visually indicate when a group is not yet complete or maximal (e.g. 2 of 3 visually different than 3 of 3)

<!--
Check relevant points but **please do not remove entries**.
-->

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [x] Details of what you changed are in commit messages
      (first line should have `module: short statement` syntax)
- [ ] References to issues, e.g. `close #X`, are in the commit messages.
- [ ] The buildserver is happy.
- [x] The PR is rebased with current master.

<!--
If you have any troubles fulfilling these criteria, please write about the trouble as comment in the PR.
We will help you, but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For documentation fixes, spell checking, and similar none of these points below need to be checked.
-->

- [ ] I added unit tests for my code
- [ ] I fully described what my PR does in the documentation
      (not in the PR description)
- [ ] I fixed all affected documentation
- [ ] I fixed all affected decisions
- [ ] I added code comments, logging, and assertions as appropriate
- [ ] I mentioned [every code](/.reuse/dep5) not directly written by me in [reuse syntax](https://reuse.software/)


## Review

<!--
Reviewers should check the following.
-->

- [ ] Documentation is conforming to [our Documentation Guidelines](/doc/documentation.md)
- [ ] Examples are well chosen and understandable
- [ ] Code is conforming to our Coding Guidelines
- [ ] Code is consistent to [our Design Decisions](/doc/decisions)
