### PR TITLE
Polyculture Use Case: Map Specific Favorite Groups

### DIFF
--- a/doc/usecases/polyculture/map_specific_favorite_groups.md
+++ b/doc/usecases/polyculture/map_specific_favorite_groups.md
@@ -1,0 +1,24 @@
+# Use Case: Map Specific Favorite Groups
+
+## Summary
+
+- **Scope:** Plants Layer
+- **Level:** User Goal
+- **Actors:** App User
+- **Brief:** The user change a set of favorite plant groups per map.
+- **Status:** Draft
+
+## Scenarios
+
+- **Precondition:**
+  - The user is logged in to the app.
+  - The plants layer is selected.
+  - At least one plant is placed
+- **Main success scenario:**
+  - The user adds or removes a plant group from her list of favorites.
+- **Alternative scenario:**
+- **Error scenario:**
+- **Postcondition:**
+  - The set of map specific favorites has changed according to the changes the user made.  
+    The state of these favorites can be seen in the map view.
+- **Non-functional Constraints:**

--- a/doc/usecases/polyculture/map_specific_favorite_groups.md
+++ b/doc/usecases/polyculture/map_specific_favorite_groups.md
@@ -22,6 +22,7 @@
   - The user wants to remove favorite plant groups.
 - **Error scenario:**
   - The user attempts to add a plant group that is already in their favorites.
+  - The user attempts to remove a group that is not in the favorites.
 - **Postcondition:**
   - The set of map-specific favorites has changed according to the changes the user made.  
     The state of these favorites can be seen in the plant layer.

--- a/doc/usecases/polyculture/map_specific_favorite_groups.md
+++ b/doc/usecases/polyculture/map_specific_favorite_groups.md
@@ -6,7 +6,8 @@
 - **Level:** User Goal
 - **Actors:** App User
 - **Brief:** The user change a set of favorite plant groups per map.
-- **Status:** Draft
+- **Status:** Assigned
+- **Assignee:** Benjamin
 
 ## Scenarios
 

--- a/doc/usecases/polyculture/map_specific_favorite_groups.md
+++ b/doc/usecases/polyculture/map_specific_favorite_groups.md
@@ -16,14 +16,14 @@
   - The plants layer is selected.
   - At least one plant is placed.
 - **Main success scenario:**
-  - The user adds or removes a plant group from her list of favorites.
+  - The user adds a plant or a plant group to her list of favorites.
 - **Alternative scenario:**
   - The user wants to reorder their list of favorite plant groups.
-  - The user wants to reset their list of favorite plant groups.
+  - The user wants to remove favorite plant groups.
 - **Error scenario:**
   - The user attempts to add a plant group that is already in their favorites.
 - **Postcondition:**
-  - The set of map specific favorites has changed according to the changes the user made.  
+  - The set of map-specific favorites has changed according to the changes the user made.  
     The state of these favorites can be seen in the plant layer.
 - **Non-functional Constraints:**
   - It must be clear that a favorite was added or removed.

--- a/doc/usecases/polyculture/map_specific_favorite_groups.md
+++ b/doc/usecases/polyculture/map_specific_favorite_groups.md
@@ -1,11 +1,11 @@
-# Use Case: Map Specific Favorite Groups
+# Use Case: Map-Specific Favorite Groups
 
 ## Summary
 
 - **Scope:** Plants Layer
 - **Level:** User Goal
 - **Actors:** App User
-- **Brief:** The user change a set of favorite plant groups per map.
+- **Brief:** The user changes a set of favorite plant groups per map.
 - **Status:** Assigned
 - **Assignee:** Benjamin
 
@@ -14,12 +14,16 @@
 - **Precondition:**
   - The user is logged in to the app.
   - The plants layer is selected.
-  - At least one plant is placed
+  - At least one plant is placed.
 - **Main success scenario:**
   - The user adds or removes a plant group from her list of favorites.
 - **Alternative scenario:**
+  - The user wants to reorder their list of favorite plant groups.
+  - The user wants to reset their list of favorite plant groups.
 - **Error scenario:**
+  - The user attempts to add a plant group that is already in their favorites.
 - **Postcondition:**
   - The set of map specific favorites has changed according to the changes the user made.  
-    The state of these favorites can be seen in the map view.
+    The state of these favorites can be seen in the plant layer.
 - **Non-functional Constraints:**
+  - It must be clear that a favorite was added or removed.


### PR DESCRIPTION
This should document the following use case from https://github.com/ElektraInitiative/PermaplanT/issues/1
> map-specific favorite groups

<!--
Check relevant points but **please do not remove entries**.
-->

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [x] Details of what you changed are in commit messages
      (first line should have `module: short statement` syntax)
- [ ] References to issues, e.g. `close #X`, are in the commit messages.
- [ ] The buildserver is happy.
- [x] The PR is rebased with current master.

<!--
If you have any troubles fulfilling these criteria, please write about the trouble as comment in the PR.
We will help you, but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For documentation fixes, spell checking, and similar none of these points below need to be checked.
-->

- [ ] I added unit tests for my code
- [ ] I fully described what my PR does in the documentation
      (not in the PR description)
- [ ] I fixed all affected documentation
- [ ] I fixed all affected decisions
- [ ] I added code comments, logging, and assertions as appropriate
- [ ] I mentioned [every code](/.reuse/dep5) not directly written by me in [reuse syntax](https://reuse.software/)


## Review

<!--
Reviewers should check the following.
-->

- [ ] Documentation is conforming to [our Documentation Guidelines](/doc/documentation.md)
- [ ] Examples are well chosen and understandable
- [ ] Code is conforming to our Coding Guidelines
- [ ] Code is consistent to [our Design Decisions](/doc/decisions)
