### PR TITLE
Put api documentation under the same path prefix

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -61,7 +61,7 @@ Example requests:
 
 ## Documentation
 
-To view an interactive API documentation go to <http://localhost:8080/doc/api/swagger-ui/>.
+To view an interactive API documentation go to <http://localhost:8080/doc/api/swagger/ui/>.
 Alternatively there is a [OpenAPI specification](https://spec.openapis.org/oas/latest.html) in json format at <http://localhost:8080/doc/api/openapi.json>.
 
 To view code documentation run

--- a/backend/README.md
+++ b/backend/README.md
@@ -61,7 +61,8 @@ Example requests:
 
 ## Documentation
 
-To view API documentation go to <http://localhost:8080/api-doc/swagger-ui/>.
+To view an interactive API documentation go to <http://localhost:8080/api-doc/swagger-ui/>.
+Alternatively there is a [OpenAPI specification](https://spec.openapis.org/oas/latest.html) in json format at <http://localhost:8080/api-doc/openapi.json>.
 
 To view code documentation run
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -61,8 +61,8 @@ Example requests:
 
 ## Documentation
 
-To view an interactive API documentation go to <http://localhost:8080/api-doc/swagger-ui/>.
-Alternatively there is a [OpenAPI specification](https://spec.openapis.org/oas/latest.html) in json format at <http://localhost:8080/api-doc/openapi.json>.
+To view an interactive API documentation go to <http://localhost:8080/doc/api/swagger-ui/>.
+Alternatively there is a [OpenAPI specification](https://spec.openapis.org/oas/latest.html) in json format at <http://localhost:8080/doc/api/openapi.json>.
 
 To view code documentation run
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -61,7 +61,7 @@ Example requests:
 
 ## Documentation
 
-To view API documentation go to <http://localhost:8080/swagger-ui/>.
+To view API documentation go to <http://localhost:8080/api-doc/swagger-ui/>.
 
 To view code documentation run
 

--- a/backend/src/config/api_doc.rs
+++ b/backend/src/config/api_doc.rs
@@ -47,5 +47,5 @@ pub fn config(cfg: &mut web::ServiceConfig) {
     let mut openapi = SeedApiDoc::openapi();
     openapi.merge(PlantsApiDoc::openapi());
 
-    cfg.service(SwaggerUi::new("/swagger-ui/{_:.*}").url("/api-doc/openapi.json", openapi));
+    cfg.service(SwaggerUi::new("/api-doc/swagger-ui/{_:.*}").url("/api-doc/openapi.json", openapi));
 }

--- a/backend/src/config/api_doc.rs
+++ b/backend/src/config/api_doc.rs
@@ -47,5 +47,5 @@ pub fn config(cfg: &mut web::ServiceConfig) {
     let mut openapi = SeedApiDoc::openapi();
     openapi.merge(PlantsApiDoc::openapi());
 
-    cfg.service(SwaggerUi::new("/doc/api/swagger-ui/{_:.*}").url("/doc/api/openapi.json", openapi));
+    cfg.service(SwaggerUi::new("/doc/api/swagger/ui/{_:.*}").url("/doc/api/openapi.json", openapi));
 }

--- a/backend/src/config/api_doc.rs
+++ b/backend/src/config/api_doc.rs
@@ -47,5 +47,5 @@ pub fn config(cfg: &mut web::ServiceConfig) {
     let mut openapi = SeedApiDoc::openapi();
     openapi.merge(PlantsApiDoc::openapi());
 
-    cfg.service(SwaggerUi::new("/api-doc/swagger-ui/{_:.*}").url("/api-doc/openapi.json", openapi));
+    cfg.service(SwaggerUi::new("/doc/api/swagger-ui/{_:.*}").url("/doc/api/openapi.json", openapi));
 }


### PR DESCRIPTION
Since the swagger UI and the OpenAPI specification are both part of the API documentation I put the former under `/api-doc/` as well.
Also mentioned the latter in the backend readme.

<!--
Check relevant points but **please do not remove entries**.
-->

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [x] Details of what you changed are in commit messages
      (first line should have `module: short statement` syntax)
- [ ] References to issues, e.g. `close #X`, are in the commit messages.
- [x] The buildserver is happy.
- [x] The PR is rebased with current master.

<!--
If you have any troubles fulfilling these criteria, please write about the trouble as comment in the PR.
We will help you, but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For documentation fixes, spell checking, and similar none of these points below need to be checked.
-->

- [ ] I added unit tests for my code
- [x] I fully described what my PR does in the documentation
      (not in the PR description)
- [x] I fixed all affected documentation
- [ ] I fixed all affected decisions
- [ ] I added code comments, logging, and assertions as appropriate
- [ ] I mentioned [every code](/.reuse/dep5) not directly written by me in [reuse syntax](https://reuse.software/)


## Review

<!--
Reviewers should check the following.
-->

- [ ] Documentation is conforming to [our Documentation Guidelines](/doc/documentation.md)
- [ ] Examples are well chosen and understandable
- [ ] Code is conforming to our Coding Guidelines
- [ ] Code is consistent to [our Design Decisions](/doc/decisions)
