### PR TITLE
Use Case: Map Timeline Single Date Selection

### DIFF
--- a/doc/usecases/map_timeline_single_date_selection.md
+++ b/doc/usecases/map_timeline_single_date_selection.md
@@ -14,7 +14,7 @@
   The user has opened the app and selected a map.
 - **Main success scenario:**
   The user selects the timeline view and uses the scroll bar with a month granularity or date field.
-  This allows navigation to a different points in the past, present and future.
+  This allows navigation to a different point in the past, present and future.
   The map updates to show the state of the garden at the selected point in time (removing or adding elements accordingly).
   The date is used as a reference to when an element (plant/construction) got added to/removed from the map.
   The scroll bar visually indicates in which months there are changes and at which months the map is empty (without plants).

--- a/doc/usecases/map_timeline_single_date_selection.md
+++ b/doc/usecases/map_timeline_single_date_selection.md
@@ -1,4 +1,4 @@
-# Use Case: Map Timeline
+# Use Case: Map Timeline Single Date Selection
 
 ## Summary
 
@@ -15,9 +15,10 @@
 - **Main success scenario:**
   The user selects the timeline view and uses the scroll bar with a month granularity or date field.
   This allows navigation to a different points in the past, present and future.
+  The map updates to show the state of the garden at the selected point in time (removing or adding elements accordingly).
+  The date is used as a reference to when an element (plant/construction) got added to/removed from the map.
   The scroll bar visually indicates in which months there are changes and at which months the map is empty (without plants).
-  During a mousehover over the scroll bar it shows hints which month would be selected on a click.
-  The map updates to show the state of the garden at the selected time.
+  Hovering over the scroll bar hints which month would be selected on a click.
 - **Alternative scenario:**
   The user tries to navigate to a date that is outside the range of the timeline (10 years). 
   In this case, the app displays an error message indicating that the requested date is not available.


### PR DESCRIPTION
This documents the following use case from #1 

> timeline single selection: select a specific date: if you drag&drop elements in or out, the date is used for seeding/constructing or removing (the plant/construction).

I adapted the already existing timeline use case, as it seemed to me that it was mostly the same.

<!--
Check relevant points but **please do not remove entries**.
-->

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [x] Details of what you changed are in commit messages
      (first line should have `module: short statement` syntax)
- [x] References to issues, e.g. `close #X`, are in the commit messages.
- [x] The buildserver is happy.
- [x] The PR is rebased with current master.

<!--
If you have any troubles fulfilling these criteria, please write about the trouble as comment in the PR.
We will help you, but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For documentation fixes, spell checking, and similar none of these points below need to be checked.
-->

- [ ] I added unit tests for my code
- [ ] I fully described what my PR does in the documentation
      (not in the PR description)
- [ ] I fixed all affected documentation
- [ ] I fixed all affected decisions
- [ ] I added code comments, logging, and assertions as appropriate
- [ ] I mentioned [every code](/.reuse/dep5) not directly written by me in [reuse syntax](https://reuse.software/)


## Review

<!--
Reviewers should check the following.
-->

- [ ] Documentation is conforming to [our Documentation Guidelines](/doc/documentation.md)
- [ ] Examples are well chosen and understandable
- [ ] Code is conforming to our Coding Guidelines
- [ ] Code is consistent to [our Design Decisions](/doc/decisions)
