### PR TITLE
Bug fix/300 mixture of languages

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "permaplant",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^4.29.1",

--- a/frontend/src/features/landing_page/components/Features.tsx
+++ b/frontend/src/features/landing_page/components/Features.tsx
@@ -12,7 +12,7 @@ interface Feature {
 }
 
 const Features = () => {
-  const { t } = useTranslation(['featureDescriptions']);
+  const { t, i18n } = useTranslation(['featureDescriptions']);
   const features: Feature[] = [
     {
       icon: PlanningSVG,
@@ -43,11 +43,13 @@ const Features = () => {
             </div>
             <div className="text-left">
               <TypewriterComponent
+                // remount the component when language changes, so that the typewriter effect is reset
+                key={i18n.resolvedLanguage}
                 onInit={(typewriter) => {
                   const strings = t('featureDescriptions:slogan.third_part', {
                     returnObjects: true,
                   });
-                  console.log(strings);
+
                   strings.forEach((s) => {
                     typewriter.typeString(s).deleteAll();
                   });


### PR DESCRIPTION
Ref: #300 
This commit fixes that the Typewriter Effect ignores the language change.
We basically need to remount the Typewriter component when the language changes.
We can do this by changing the `key` prop, which remounts the component. 

More generally, changing the `key` prop of a component remounts it.

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [X] Details of what you changed are in commit messages.
- [X] References to issues, e.g. `close #X`, are in the commit messages.
- [X] The buildserver is happy.
- [X] The PR is rebased with current master.

<!--
If you have any troubles fulfilling these criteria, please write about the trouble as comment in the PR.
We will help you, but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For documentation fixes, spell checking, and similar none of these points below need to be checked.
-->

- [ ] I added unit tests for my code
- [ ] I fully described what my PR does in the documentation
      (not in the PR description)
- [ ] I fixed all affected documentation
- [ ] I fixed all affected decisions
- [X] I added code comments, logging, and assertions as appropriate
- [ ] I translated all strings visible to the user
- [ ] I mentioned [every code or binary](/.reuse/dep5) not directly written or done by me in [reuse syntax](https://reuse.software/)

## Review

<!--
Reviewers can copy&check the following to their review
-->

- [ ] I've tested the code
- [ ] I've read through the whole code
- [ ] Documentation is conforming to [our Documentation Guidelines](/doc/documentation.md)
- [ ] Examples are well chosen and understandable
- [ ] Code is conforming to our Coding Guidelines
- [ ] Code is consistent to [our Design Decisions](/doc/decisions)
