### PR TITLE
Fixed long waiting times for map overview to update

### DIFF
--- a/frontend/src/features/maps/routes/MapCreateForm.tsx
+++ b/frontend/src/features/maps/routes/MapCreateForm.tsx
@@ -73,7 +73,7 @@ export default function MapCreateForm() {
       description: mapInput.description,
       location: !Number.isNaN(mapInput.location.latitude) ? mapInput.location : undefined,
     };
-    createMap(newMap);
+    await createMap(newMap);
     navigate('/maps');
   }
 

--- a/frontend/src/features/maps/routes/MapOverview.tsx
+++ b/frontend/src/features/maps/routes/MapOverview.tsx
@@ -6,7 +6,7 @@ import InfoMessage, { InfoMessageType } from '@/components/Card/InfoMessage';
 import PageTitle from '@/components/Header/PageTitle';
 import Footer from '@/components/Layout/Footer';
 import PageLayout from '@/components/Layout/PageLayout';
-import { getUser } from '@/utils/getUser';
+import { useSafeAuth } from '@/hooks/useSafeAuth';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { Suspense, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -18,17 +18,20 @@ export default function MapOverview() {
     message: '',
   };
 
+  const { user } = useSafeAuth();
   const navigate = useNavigate();
   const { t } = useTranslation(['maps']);
   const [infoMessage, setInfoMessage] = useState(initialMessage);
 
   const searchParams: MapSearchParameters = {
-    owner_id: getUser()?.profile.sub,
+    owner_id: user?.profile.sub,
   };
+
   const { data } = useInfiniteQuery({
-    queryKey: ['maps'],
-    queryFn: ({ pageParam = 1 }) => findAllMaps(pageParam, searchParams),
+    queryKey: ['maps', searchParams] as const,
+    queryFn: ({ pageParam = 1, queryKey: [, params] }) => findAllMaps(pageParam, params),
     getNextPageParam: (lastPage) => lastPage.page + 1,
+    staleTime: 0,
   });
 
   const maps = data?.pages.flatMap((page) => page.results) ?? [];

--- a/frontend/src/features/maps/routes/MapOverview.tsx
+++ b/frontend/src/features/maps/routes/MapOverview.tsx
@@ -31,7 +31,6 @@ export default function MapOverview() {
     queryKey: ['maps', searchParams] as const,
     queryFn: ({ pageParam = 1, queryKey: [, params] }) => findAllMaps(pageParam, params),
     getNextPageParam: (lastPage) => lastPage.page + 1,
-    staleTime: 0,
   });
 
   const maps = data?.pages.flatMap((page) => page.results) ?? [];


### PR DESCRIPTION
A missing `await` after the map creation request seemed to have caused a race condition, where the map overview page was fetching map data before the new map was successfully created.

Resolves #489.

<!--
Check relevant points but **please do not remove entries**.
-->

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [ ] The PR is rebased with current master.
- [ ] Details of what you changed are in commit messages.
- [ ] References to issues, e.g. `close #X`, are in the commit messages.
- [ ] The buildserver is happy.

<!--
If you have any troubles fulfilling these criteria, please write about the trouble as comment in the PR.
We will help you, but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For documentation fixes, spell checking, and similar none of these points below need to be checked.
-->

- [ ] I fully described what my PR does in the documentation
      (not in the PR description)
- [ ] I fixed all affected documentation
- [ ] I fixed all affected decisions
- [ ] I added unit tests for my code
- [ ] I added code comments, logging, and assertions as appropriate
- [ ] I translated all strings visible to the user
- [ ] I mentioned [every code or binary](/.reuse/dep5) not directly written or done by me in [reuse syntax](https://reuse.software/)
- [ ] I created left-over issues for things that are still to be done
- [ ] Code is conforming to [our Architecture](/doc/architecture)
- [ ] Code is conforming to [our Guidelines](/doc/guidelines)
      (exceptions are documented)
- [ ] Code is consistent to [our Design Decisions](/doc/decisions)

## Review

<!--
Reviewers can copy&check the following to their review.
Also the checklist above can be used.
-->

- [ ] I've tested the code
- [ ] I've read through the whole code
- [ ] Examples are well chosen and understandable
