### PR TITLE
fix: timeline not working correctly with collaboration

### DIFF
--- a/backend/src/model/dto/actions.rs
+++ b/backend/src/model/dto/actions.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::missing_const_for_fn)]
 
 use crate::model::dto::plantings::PlantingDto;
+use chrono::NaiveDate;
 use serde::Serialize;
 use typeshare::typeshare;
 use uuid::Uuid;
@@ -45,6 +46,8 @@ pub struct CreatePlantActionPayload {
     rotation: f32,
     scale_x: f32,
     scale_y: f32,
+    add_date: Option<NaiveDate>,
+    remove_date: Option<NaiveDate>,
 }
 
 impl CreatePlantActionPayload {
@@ -62,6 +65,8 @@ impl CreatePlantActionPayload {
             rotation: payload.rotation,
             scale_x: payload.scale_x,
             scale_y: payload.scale_y,
+            add_date: payload.add_date,
+            remove_date: payload.remove_date,
         }
     }
 }

--- a/backend/src/model/dto/plantings.rs
+++ b/backend/src/model/dto/plantings.rs
@@ -10,14 +10,13 @@ use uuid::Uuid;
 /// E.g. a user drags a plant from the search results and drops it on the map.
 #[typeshare]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct PlantingDto {
     /// The id of the planting.
     pub id: Uuid,
     /// The plant layer the plantings is on.
-    #[serde(rename = "layerId")]
     pub layer_id: i32,
     /// The plant that is planted.
-    #[serde(rename = "plantId")]
     pub plant_id: i32,
     /// The x coordinate of the position on the map.
     pub x: i32,
@@ -30,10 +29,8 @@ pub struct PlantingDto {
     /// The rotation in degrees (0-360) of the plant on the map.
     pub rotation: f32,
     /// The x scale of the plant on the map.
-    #[serde(rename = "scaleX")]
     pub scale_x: f32,
     /// The y scale of the plant on the map.
-    #[serde(rename = "scaleY")]
     pub scale_y: f32,
     /// The date the planting was added to the map.
     /// If None, the planting always existed.
@@ -46,14 +43,13 @@ pub struct PlantingDto {
 /// Used to create a new planting.
 #[typeshare]
 #[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct NewPlantingDto {
     /// The id of the planting.
     pub id: Option<Uuid>,
     /// The plant layer the plantings is on.
-    #[serde(rename = "layerId")]
     pub layer_id: i32,
     /// The plant that is planted.
-    #[serde(rename = "plantId")]
     pub plant_id: i32,
     /// The x coordinate of the position on the map.
     pub x: i32,
@@ -66,10 +62,8 @@ pub struct NewPlantingDto {
     /// The rotation of the plant on the map.
     pub rotation: f32,
     /// The x scale of the plant on the map.
-    #[serde(rename = "scaleX")]
     pub scale_x: f32,
     /// The y scale of the plant on the map.
-    #[serde(rename = "scaleY")]
     pub scale_y: f32,
     /// The date the planting was added to the map.
     /// If None, the planting always existed.
@@ -93,6 +87,7 @@ pub enum UpdatePlantingDto {
 /// Used to transform an existing planting.
 #[typeshare]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct TransformPlantingDto {
     /// The x coordinate of the position on the map.
     pub x: i32,
@@ -101,16 +96,15 @@ pub struct TransformPlantingDto {
     /// The rotation of the plant on the map.
     pub rotation: f32,
     /// The x scale of the plant on the map.
-    #[serde(rename = "scaleX")]
     pub scale_x: f32,
     /// The y scale of the plant on the map.
-    #[serde(rename = "scaleY")]
     pub scale_y: f32,
 }
 
 /// Used to move an existing planting.
 #[typeshare]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct MovePlantingDto {
     /// The x coordinate of the position on the map.
     pub x: i32,

--- a/frontend/src/features/map_planning/layers/plant/PlantsLayer.tsx
+++ b/frontend/src/features/map_planning/layers/plant/PlantsLayer.tsx
@@ -49,7 +49,7 @@ function usePlantLayerListeners(listening: boolean) {
           rotation: 0,
           scaleX: 1,
           scaleY: 1,
-          add_date: timelineDate,
+          addDate: timelineDate,
         }),
       );
     },

--- a/frontend/src/features/map_planning/layers/plant/actions.ts
+++ b/frontend/src/features/map_planning/layers/plant/actions.ts
@@ -5,7 +5,9 @@ import { createPlanting } from '../../api/createPlanting';
 import { deletePlanting } from '../../api/deletePlanting';
 import { movePlanting } from '../../api/movePlanting';
 import { transformPlanting } from '../../api/transformPlanting';
+import useMapStore from '../../store/MapStore';
 import { Action, TrackedMapState } from '../../store/MapStoreTypes';
+import { convertToDate } from '../../utils/date-utils';
 import { PlantingDto } from '@/bindings/definitions';
 
 export class CreatePlantAction
@@ -27,13 +29,20 @@ export class CreatePlantAction
       id: this._id,
     };
 
+    const timelineDate = convertToDate(useMapStore.getState().untrackedState.timelineDate);
+    const addDate = this._data.addDate ? convertToDate(this._data.addDate) : null;
+
+    const shouldBeVisible = addDate === null || addDate <= timelineDate;
+
     return {
       ...state,
       layers: {
         ...state.layers,
         plants: {
           ...state.layers.plants,
-          objects: [...state.layers.plants.objects, { ...newPlant }],
+          objects: shouldBeVisible
+            ? [...state.layers.plants.objects, { ...newPlant }]
+            : state.layers.plants.objects,
           loadedObjects: [...state.layers.plants.loadedObjects, { ...newPlant }],
         },
       },

--- a/frontend/src/features/map_planning/store/MapStore.ts
+++ b/frontend/src/features/map_planning/store/MapStore.ts
@@ -2,6 +2,7 @@ import type { TrackedMapSlice, UntrackedMapSlice } from './MapStoreTypes';
 import { createTrackedMapSlice } from './TrackedMapStore';
 import { createUntrackedMapSlice } from './UntrackedMapStore';
 import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
 
 /**
  * This is the main store for the map planning feature.
@@ -12,9 +13,14 @@ import { create } from 'zustand';
  * - `UntrackedMapStore`: stores the state of the map that is not tracked by the history
  * (e.g. the selected layer and the layer opacities).
  */
-const useMapStore = create<TrackedMapSlice & UntrackedMapSlice>()((...a) => ({
-  ...createUntrackedMapSlice(...a),
-  ...createTrackedMapSlice(...a),
-}));
+const useMapStore = create<TrackedMapSlice & UntrackedMapSlice>()(
+  devtools(
+    (...a) => ({
+      ...createUntrackedMapSlice(...a),
+      ...createTrackedMapSlice(...a),
+    }),
+    { name: 'MapStore' },
+  ),
+);
 
 export default useMapStore;

--- a/frontend/src/features/map_planning/utils/filterVisibleObjects.ts
+++ b/frontend/src/features/map_planning/utils/filterVisibleObjects.ts
@@ -1,8 +1,8 @@
 import { convertToDate } from './date-utils';
 
 interface ObjectWithDates {
-  add_date?: string;
-  remove_date?: string;
+  addDate?: string;
+  removeDate?: string;
 }
 
 /**
@@ -15,8 +15,8 @@ export function filterVisibleObjects<T extends ObjectWithDates>(
   const date = convertToDate(dateStr);
 
   return objects.filter((o) => {
-    const addDate = o.add_date ? convertToDate(o.add_date) : undefined;
-    const removeDate = o.remove_date ? convertToDate(o.remove_date) : undefined;
+    const addDate = o.addDate ? convertToDate(o.addDate) : undefined;
+    const removeDate = o.removeDate ? convertToDate(o.removeDate) : undefined;
 
     if (isVisible(date, addDate, removeDate)) {
       return true;


### PR DESCRIPTION
Ref: #641 

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [X] I added a line to [/doc/CHANGELOG.md](/doc/CHANGELOG.md)
- [X] The PR is rebased with current master.
- [X] Details of what you changed are in commit messages.
- [X] References to issues, e.g. `close #X`, are in the commit messages.
- [ ] The buildserver is happy.

<!--
If you have any troubles fulfilling these criteria, please write about the trouble as comment in the PR.
We will help you, but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For documentation fixes, spell checking, and similar none of these points below need to be checked.
Otherwise please check these points when getting a PR done:
-->

- [ ] I have installed and I am using [pre-commit hooks](../doc/contrib/README.md#Hooks)
- [ ] I fully described what my PR does in the documentation
      (not in the PR description)
- [ ] I fixed all affected documentation
- [ ] I fixed all affected decisions
- [ ] I added unit tests for my code
- [ ] I added code comments, logging, and assertions as appropriate
- [ ] I translated all strings visible to the user
- [ ] I mentioned [every code or binary](https://github.com/ElektraInitiative/PermaplanT/blob/master/.reuse/dep5) not directly written or done by me in [reuse syntax](https://reuse.software/)
- [ ] I created left-over issues for things that are still to be done
- [ ] Code is conforming to [our Architecture](/doc/architecture)
- [ ] Code is conforming to [our Guidelines](/doc/guidelines)
      (exceptions are documented)
- [ ] Code is consistent to [our Design Decisions](/doc/decisions)

## Review

<!--
Reviewers can copy&check the following to their review.
Also the checklist above can be used.
But also the PR creator should check these points when getting a PR done:
-->

- [ ] I've tested the code
- [ ] I've read through the whole code
- [ ] Examples are well chosen and understandable
