### PR TITLE
Fix: Timeline issues

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -36,7 +36,7 @@ Syntax: `- short text describing the change _(Your Name)_`
 - _()_
 - _()_
 - Handle events of same user, discard events in same tab _(Paul)_
-- _()_
+- Fix a bug in the date handling actions of plants _(Paul)_
 - _()_
 - Add debouncing to base layer toolbar _(Moritz)_
 - _()_

--- a/frontend/src/features/map_planning/layers/plant/actions.ts
+++ b/frontend/src/features/map_planning/layers/plant/actions.ts
@@ -331,7 +331,10 @@ export class UpdateAddDatePlantAction
         ...state.layers,
         plants: {
           ...state.layers.plants,
-          objects: filterVisibleObjects(updatePlants(state.layers.plants.objects), timelineDate),
+          objects: filterVisibleObjects(
+            updatePlants(state.layers.plants.loadedObjects),
+            timelineDate,
+          ),
           loadedObjects: updatePlants(state.layers.plants.loadedObjects),
         },
       },
@@ -400,7 +403,10 @@ export class UpdateRemoveDatePlantAction
         ...state.layers,
         plants: {
           ...state.layers.plants,
-          objects: filterVisibleObjects(updatePlants(state.layers.plants.objects), timelineDate),
+          objects: filterVisibleObjects(
+            updatePlants(state.layers.plants.loadedObjects),
+            timelineDate,
+          ),
           loadedObjects: updatePlants(state.layers.plants.loadedObjects),
         },
       },

--- a/frontend/src/hooks/useDebounceEffect.tsx
+++ b/frontend/src/hooks/useDebounceEffect.tsx
@@ -1,25 +1,43 @@
-import { DependencyList, EffectCallback, useEffect } from 'react';
+import { DependencyList, EffectCallback, useEffect, useRef } from 'react';
 
 /**
  * Takes a value, a function and a delay and runs the function after the delay as long as the function does not change.
+ * Unmounting the component before the delay is over will run the function immediately.
  */
 function useDebounceEffect(
   effect: EffectCallback,
   delay: number,
   deps?: DependencyList | undefined,
 ) {
+  const effectRef = useRef(effect);
+  const didRunRef = useRef(false);
+
+  useEffect(() => {
+    effectRef.current = effect;
+  }, [effect]);
+
+  useEffect(() => {
+    return () => {
+      if (!didRunRef.current) {
+        effectRef.current?.();
+      }
+    };
+  }, []);
+
   useEffect(() => {
     let cleanup: void | (() => void);
     const timeout = setTimeout(() => {
-      cleanup = effect();
+      cleanup = effectRef.current?.();
+      didRunRef.current = true;
     }, delay);
 
     return () => {
       clearTimeout(timeout);
+      didRunRef.current = false;
       cleanup?.();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [effect, delay, ...(deps ?? [])]);
+  }, [delay, ...(deps ?? [])]);
 
   return;
 }


### PR DESCRIPTION
Ref: #705 

Plantings where not added back to the visible elements if the add_date would have allowed it.
This was just a logic bug in my code.

The second issue was, that the component got unmounted and thus the effect in useDebounceEffect was just cancelled with `clearTimeout()`.
Now useDebounceEffect saves a reference to the effect function passed in and also saves if it was called.
When the component is unmounted the effect is called, if it was not called before.

<!--
Check relevant points but **please do not remove entries**.
-->

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [X] I added a line to [/doc/CHANGELOG.md](/doc/CHANGELOG.md)
- [X] The PR is rebased with current master.
- [X] Details of what you changed are in commit messages.
- [X] References to issues, e.g. `close #X`, are in the commit messages.
- [X] The buildserver is happy.

<!--
If you have any troubles fulfilling these criteria, please write about the trouble as comment in the PR.
We will help you, but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For documentation fixes, spell checking, and similar none of these points below need to be checked.
Otherwise please check these points when getting a PR done:
-->

- [ ] I have installed and I am using [pre-commit hooks](../doc/contrib/README.md#Hooks)
- [ ] I fully described what my PR does in the documentation
      (not in the PR description)
- [ ] I fixed all affected documentation
- [ ] I fixed the introduction tour
- [ ] I wrote migrations in a way that they are compatible with already present data
- [ ] I fixed all affected decisions
- [ ] I added unit tests for my code
- [ ] I added code comments, logging, and assertions as appropriate
- [ ] I translated all strings visible to the user
- [ ] I mentioned [every code or binary](https://github.com/ElektraInitiative/PermaplanT/blob/master/.reuse/dep5) not directly written or done by me in [reuse syntax](https://reuse.software/)
- [ ] I created left-over issues for things that are still to be done
- [ ] Code is conforming to [our Architecture](/doc/architecture)
- [ ] Code is conforming to [our Guidelines](/doc/guidelines)
      (exceptions are documented)
- [ ] Code is consistent to [our Design Decisions](/doc/decisions)

## Review

<!--
Reviewers can copy&check the following to their review.
Also the checklist above can be used.
But also the PR creator should check these points when getting a PR done:
-->

- [ ] I've tested the code
- [ ] I've read through the whole code
- [ ] Examples are well chosen and understandable
