### PR TITLE
basic baseLayerConfig validation

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -47,7 +47,7 @@ Syntax: `- short text describing the change _(Your Name)_`
 - _()_
 - _()_
 - _()_
-- _()_
+- basic baseLayerConfig validation - fixed bugfix/734-base-layer-image-gets-lost _(Samuel)_
 - _()_
 - _()_
 - _()_

--- a/frontend/src/features/map_planning/layers/base/components/BaseLayerRightToolbar.tsx
+++ b/frontend/src/features/map_planning/layers/base/components/BaseLayerRightToolbar.tsx
@@ -9,7 +9,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FileStat } from 'webdav';
 
-function validatebaseLayerOptions(baseLayerOptions: Omit<BaseLayerImageDto, 'action_id'>) {
+function validateBaseLayerOptions(baseLayerOptions: Omit<BaseLayerImageDto, 'action_id'>) {
   const { id, layer_id, path, rotation, scale } = baseLayerOptions;
 
   if (!id || !layer_id || !path || !rotation || !scale) {
@@ -61,7 +61,7 @@ export const BaseLayerRightToolbar = () => {
       rotation: debouncedRotation,
       scale: debouncedScale,
     };
-    if (validatebaseLayerOptions(baseLayerOptions))
+    if (validateBaseLayerOptions(baseLayerOptions))
       executeAction(new UpdateBaseLayerAction(baseLayerOptions));
   }, [
     baseLayerState.imageId,

--- a/frontend/src/features/map_planning/layers/base/components/BaseLayerRightToolbar.tsx
+++ b/frontend/src/features/map_planning/layers/base/components/BaseLayerRightToolbar.tsx
@@ -1,4 +1,5 @@
 import { UpdateBaseLayerAction } from '../../../layers/base/actions';
+import { BaseLayerImageDto } from '@/bindings/definitions';
 import SimpleButton from '@/components/Button/SimpleButton';
 import SimpleFormInput from '@/components/Form/SimpleFormInput';
 import useMapStore from '@/features/map_planning/store/MapStore';
@@ -7,6 +8,16 @@ import useDebouncedValue from '@/hooks/useDebouncedValue';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FileStat } from 'webdav';
+
+function validatebaseLayerOptions(baseLayerOptions: Omit<BaseLayerImageDto, 'action_id'>) {
+  const { id, layer_id, path, rotation, scale } = baseLayerOptions;
+
+  if (!id || !layer_id || !path || !rotation || !scale) {
+    console.log('BaseLayer validation error');
+    return false;
+  }
+  return true;
+}
 
 export const BaseLayerRightToolbar = () => {
   const baseLayerState = useMapStore((state) => state.trackedState.layers.base);
@@ -43,15 +54,15 @@ export const BaseLayerRightToolbar = () => {
   const debouncedScale = useDebouncedValue(scaleInput, 200);
 
   useEffect(() => {
-    executeAction(
-      new UpdateBaseLayerAction({
-        id: baseLayerState.imageId,
-        layer_id: baseLayerState.layerId,
-        path: debouncedPath,
-        rotation: debouncedRotation,
-        scale: debouncedScale,
-      }),
-    );
+    const baseLayerOptions = {
+      id: baseLayerState.imageId,
+      layer_id: baseLayerState.layerId,
+      path: debouncedPath,
+      rotation: debouncedRotation,
+      scale: debouncedScale,
+    };
+    if (validatebaseLayerOptions(baseLayerOptions))
+      executeAction(new UpdateBaseLayerAction(baseLayerOptions));
   }, [
     baseLayerState.imageId,
     baseLayerState.layerId,


### PR DESCRIPTION
This PR prevents sending faulty baseLayerConfig at page load.

This was the easiest fix I could do.
There are still some open questions/issues that need to be addressed.

1. The baseLayerImage config gets submitted without any user interaction at page load (might have to do with the debounce implementation idk atm). The consequence was that the config on the server gets overwritten with default values. I have not changed this yet but preventing a faulty config to be submitted fixed this bug for now.
2. I noticed a lot of dead code / comments in the BaseLayerRightToolbar component. This needs some clean up. 

<!--
Check relevant points but **please do not remove entries**.
-->

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [x] I added a line to [/doc/CHANGELOG.md](/doc/CHANGELOG.md)
- [x] The PR is rebased with current master.
- [x] Details of what you changed are in commit messages.
- [ ] References to issues, e.g. `close #X`, are in the commit messages.
- [ ] The buildserver is happy.

<!--
If you have any troubles fulfilling these criteria, please write about the trouble as comment in the PR.
We will help you, but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For documentation fixes, spell checking, and similar none of these points below need to be checked.
Otherwise please check these points when getting a PR done:
-->

- [ ] I have installed and I am using [pre-commit hooks](../doc/contrib/README.md#Hooks)
- [ ] I fully described what my PR does in the documentation
      (not in the PR description)
- [ ] I fixed all affected documentation
- [ ] I fixed the introduction tour
- [ ] I wrote migrations in a way that they are compatible with already present data
- [ ] I fixed all affected decisions
- [ ] I added unit tests for my code
- [ ] I added code comments, logging, and assertions as appropriate
- [ ] I translated all strings visible to the user
- [ ] I mentioned [every code or binary](https://github.com/ElektraInitiative/PermaplanT/blob/master/.reuse/dep5) not directly written or done by me in [reuse syntax](https://reuse.software/)
- [ ] I created left-over issues for things that are still to be done
- [x] Code is conforming to [our Architecture](/doc/architecture)
- [x] Code is conforming to [our Guidelines](/doc/guidelines)
      (exceptions are documented)
- [x] Code is consistent to [our Design Decisions](/doc/decisions)

## Review

<!--
Reviewers can copy&check the following to their review.
Also the checklist above can be used.
But also the PR creator should check these points when getting a PR done:
-->

- [ ] I've tested the code
- [ ] I've read through the whole code
- [ ] Examples are well chosen and understandable
