### PR TITLE
Bugfix/772 undo after planting a plant leaves select box behind

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -24,8 +24,8 @@ Syntax: `- short text describing the change _(Your Name)_`
 - _()_
 - _()_
 - _()_
-- _()_
-- _()_
+- Fix a bug where an 'empty' but visible selection box would be left behind _(Paul)_
+- Fix a bug where seemingly random date change actions would be fired _(Paul)_
 - _()_
 - _()_
 - _()_

--- a/frontend/src/features/map_planning/layers/plant/actions.ts
+++ b/frontend/src/features/map_planning/layers/plant/actions.ts
@@ -375,7 +375,7 @@ export class UpdateRemoveDatePlantAction
     return new UpdateRemoveDatePlantAction(
       {
         id: plant.id,
-        removeDate: plant.addDate,
+        removeDate: plant.removeDate,
       },
       this.actionId,
     );

--- a/frontend/src/features/map_planning/layers/plant/components/PlantingAttributeEditForm.tsx
+++ b/frontend/src/features/map_planning/layers/plant/components/PlantingAttributeEditForm.tsx
@@ -13,17 +13,14 @@ import { z } from 'zod';
 export type PlantingAttributeEditFormData = Pick<PlantingDto, 'addDate' | 'removeDate'>;
 
 const PlantingAttributeEditFormSchema = z
+  // The 'empty' value for the API is undefined, so we need to transform the empty string to undefined
   .object({
-    addDate: z.nullable(z.string()).transform((value) => value || null),
-    removeDate: z.nullable(z.string()).transform((value) => value || null),
+    addDate: z.nullable(z.string()).transform((value) => value || undefined),
+    removeDate: z.nullable(z.string()).transform((value) => value || undefined),
   })
-  .refine(
-    (schema) =>
-      schema.removeDate === null || schema.addDate === null || schema.addDate < schema.removeDate,
-    {
-      path: ['dateRelation'],
-    },
-  );
+  .refine((schema) => !schema.removeDate || !schema.addDate || schema.addDate < schema.removeDate, {
+    path: ['dateRelation'],
+  });
 
 export type PlantingAttributeEditFormProps = {
   planting: PlantingDto;
@@ -43,9 +40,10 @@ export function PlantingAttributeEditForm({
   const { t } = useTranslation(['plantings']);
 
   const { register, handleSubmit, watch, formState } = useForm<PlantingAttributeEditFormData>({
+    // The 'empty' value for the native date input is an empty string, not null | undefined
     defaultValues: {
-      addDate: planting.addDate,
-      removeDate: planting.removeDate,
+      addDate: planting.addDate || '',
+      removeDate: planting.removeDate || '',
     },
     resolver: zodResolver(PlantingAttributeEditFormSchema),
   });
@@ -67,7 +65,7 @@ export function PlantingAttributeEditForm({
   return (
     <div className="flex flex-col gap-2 p-2">
       <h2>
-        <ExtendedPlantsSummaryDisplayName plant={plant}></ExtendedPlantsSummaryDisplayName>
+        <ExtendedPlantsSummaryDisplayName plant={plant} />
       </h2>
 
       <div className="flex gap-2">

--- a/frontend/src/features/map_planning/store/MapStoreTypes.ts
+++ b/frontend/src/features/map_planning/store/MapStoreTypes.ts
@@ -10,8 +10,13 @@ import { FrontendOnlyLayerType } from '@/features/map_planning/layers/_frontend_
 import Konva from 'konva';
 import { Node } from 'konva/lib/Node';
 import * as uuid from 'uuid';
+import { StateCreator } from 'zustand';
 
 import Vector2d = Konva.Vector2d;
+
+export type MapCreator = StateCreator<TrackedMapSlice & UntrackedMapSlice, [], []>;
+export type SetFn = Parameters<MapCreator>[0];
+export type GetFn = Parameters<MapCreator>[1];
 
 /**
  * This type combines layers that are only available in the frontend

--- a/frontend/src/features/map_planning/store/TrackedMapStore.ts
+++ b/frontend/src/features/map_planning/store/TrackedMapStore.ts
@@ -1,19 +1,19 @@
 import { filterVisibleObjects } from '../utils/filterVisibleObjects';
 import {
   Action,
+  GetFn,
+  SetFn,
   TRACKED_DEFAULT_STATE,
   TrackedMapSlice,
   UNTRACKED_DEFAULT_STATE,
   UntrackedMapSlice,
 } from './MapStoreTypes';
+import { handleSelectedNodesChange } from './utils';
 import { BaseLayerImageDto, PlantingDto } from '@/bindings/definitions';
 import Konva from 'konva';
 import { Node } from 'konva/lib/Node';
 import { createRef } from 'react';
 import type { StateCreator } from 'zustand';
-
-type SetFn = Parameters<typeof createTrackedMapSlice>[0];
-type GetFn = Parameters<typeof createTrackedMapSlice>[1];
 
 export const createTrackedMapSlice: StateCreator<
   TrackedMapSlice & UntrackedMapSlice,
@@ -230,19 +230,4 @@ function redo(set: SetFn, get: GetFn): void {
     canUndo: true,
     canRedo: state.step + 1 < state.history.length,
   }));
-}
-/**
- * Handle the case where the selected nodes are not in the stage anymore.
- */
-function handleSelectedNodesChange(get: GetFn) {
-  const stage = get().stageRef.current;
-  const transformer = get().transformer.current;
-  const selectedNodeIds = transformer?.getNodes().map((n) => n.id()) || [];
-
-  const selectedNodesAreVisible = selectedNodeIds.every((id) => stage?.findOne(`#${id}`));
-
-  if (!selectedNodesAreVisible) {
-    transformer?.nodes([]);
-    get().selectPlanting(null);
-  }
 }

--- a/frontend/src/features/map_planning/store/TrackedMapStore.ts
+++ b/frontend/src/features/map_planning/store/TrackedMapStore.ts
@@ -8,7 +8,7 @@ import {
   UNTRACKED_DEFAULT_STATE,
   UntrackedMapSlice,
 } from './MapStoreTypes';
-import { handleSelectedNodesChange } from './utils';
+import { clearInvalidSelection } from './utils';
 import { BaseLayerImageDto, PlantingDto } from '@/bindings/definitions';
 import Konva from 'konva';
 import { Node } from 'konva/lib/Node';
@@ -113,7 +113,7 @@ function executeAction(action: Action<unknown, unknown>, set: SetFn, get: GetFn)
   action.execute(get().untrackedState.mapId);
   trackReverseActionInHistory(action, get().step, set, get);
   applyActionToStore(action, set, get);
-  handleSelectedNodesChange(get);
+  clearInvalidSelection(get);
 
   set((state) => ({
     ...state,
@@ -195,7 +195,7 @@ function undo(set: SetFn, get: GetFn): void {
   actionToUndo.execute(get().untrackedState.mapId);
   trackReverseActionInHistory(actionToUndo, get().step - 1, set, get);
   applyActionToStore(actionToUndo, set, get);
-  handleSelectedNodesChange(get);
+  clearInvalidSelection(get);
 
   set((state) => ({
     ...state,
@@ -222,7 +222,7 @@ function redo(set: SetFn, get: GetFn): void {
   actionToRedo.execute(get().untrackedState.mapId);
   trackReverseActionInHistory(actionToRedo, get().step, set, get);
   applyActionToStore(actionToRedo, set, get);
-  handleSelectedNodesChange(get);
+  clearInvalidSelection(get);
 
   set((state) => ({
     ...state,

--- a/frontend/src/features/map_planning/store/UntrackedMapStore.ts
+++ b/frontend/src/features/map_planning/store/UntrackedMapStore.ts
@@ -6,6 +6,7 @@ import {
   UNTRACKED_DEFAULT_STATE,
   UntrackedMapSlice,
 } from './MapStoreTypes';
+import { handleSelectedNodesChange } from './utils';
 import { FrontendOnlyLayerType } from '@/features/map_planning/layers/_frontend_only';
 import Konva from 'konva';
 import { Vector2d } from 'konva/lib/types';
@@ -180,6 +181,8 @@ export const createUntrackedMapSlice: StateCreator<
           fetchDate: date,
         },
       }));
+
+      handleSelectedNodesChange(get);
       return;
     }
 
@@ -201,6 +204,7 @@ export const createUntrackedMapSlice: StateCreator<
         },
       },
     }));
+    handleSelectedNodesChange(get);
   },
   /**
    * Allow the user to make measurement inputs on the base layer.

--- a/frontend/src/features/map_planning/store/UntrackedMapStore.ts
+++ b/frontend/src/features/map_planning/store/UntrackedMapStore.ts
@@ -6,7 +6,7 @@ import {
   UNTRACKED_DEFAULT_STATE,
   UntrackedMapSlice,
 } from './MapStoreTypes';
-import { handleSelectedNodesChange } from './utils';
+import { clearInvalidSelection } from './utils';
 import { FrontendOnlyLayerType } from '@/features/map_planning/layers/_frontend_only';
 import Konva from 'konva';
 import { Vector2d } from 'konva/lib/types';
@@ -182,7 +182,7 @@ export const createUntrackedMapSlice: StateCreator<
         },
       }));
 
-      handleSelectedNodesChange(get);
+      clearInvalidSelection(get);
       return;
     }
 
@@ -204,7 +204,7 @@ export const createUntrackedMapSlice: StateCreator<
         },
       },
     }));
-    handleSelectedNodesChange(get);
+    clearInvalidSelection(get);
   },
   /**
    * Allow the user to make measurement inputs on the base layer.

--- a/frontend/src/features/map_planning/store/utils.ts
+++ b/frontend/src/features/map_planning/store/utils.ts
@@ -1,9 +1,9 @@
 import { GetFn } from './MapStoreTypes';
 
 /**
- * Handle the case where the selected nodes are not in the stage anymore.
+ * If any of the selected nodes can not be found on the map, clear the selection.
  */
-export function handleSelectedNodesChange(get: GetFn) {
+export function clearInvalidSelection(get: GetFn) {
   const stage = get().stageRef.current;
   const transformer = get().transformer.current;
   const selectedNodeIds = transformer?.getNodes().map((n) => n.id()) || [];

--- a/frontend/src/features/map_planning/store/utils.ts
+++ b/frontend/src/features/map_planning/store/utils.ts
@@ -1,0 +1,17 @@
+import { GetFn } from './MapStoreTypes';
+
+/**
+ * Handle the case where the selected nodes are not in the stage anymore.
+ */
+export function handleSelectedNodesChange(get: GetFn) {
+  const stage = get().stageRef.current;
+  const transformer = get().transformer.current;
+  const selectedNodeIds = transformer?.getNodes().map((n) => n.id()) || [];
+
+  const selectedNodesAreVisible = selectedNodeIds.every((id) => stage?.findOne(`#${id}`));
+
+  if (!selectedNodesAreVisible) {
+    transformer?.nodes([]);
+    get().selectPlanting(null);
+  }
+}


### PR DESCRIPTION
Fixes a few bugs related to the planting dates and inputs.
It also fixes the invalid selection box issue.

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [x] I added a line to [/doc/CHANGELOG.md](/doc/CHANGELOG.md)
- [X] The PR is rebased with current master.
- [X] Details of what you changed are in commit messages.
- [X] References to issues, e.g. `close #X`, are in the commit messages.
- [X] The buildserver is happy.

<!--
If you have any troubles fulfilling these criteria, please write about the trouble as comment in the PR.
We will help you, but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For documentation fixes, spell checking, and similar none of these points below need to be checked.
Otherwise please check these points when getting a PR done:
-->

- [X] I have installed and I am using [pre-commit hooks](../doc/contrib/README.md#Hooks)
- [ ] I fully described what my PR does in the documentation
      (not in the PR description)
- [ ] I fixed all affected documentation
- [ ] I fixed the introduction tour
- [ ] I wrote migrations in a way that they are compatible with already present data
- [ ] I fixed all affected decisions
- [ ] I added unit tests for my code
- [ ] I added code comments, logging, and assertions as appropriate
- [ ] I translated all strings visible to the user
- [ ] I mentioned [every code or binary](https://github.com/ElektraInitiative/PermaplanT/blob/master/.reuse/dep5) not directly written or done by me in [reuse syntax](https://reuse.software/)
- [ ] I created left-over issues for things that are still to be done
- [ ] Code is conforming to [our Architecture](/doc/architecture)
- [ ] Code is conforming to [our Guidelines](/doc/guidelines)
      (exceptions are documented)
- [ ] Code is consistent to [our Design Decisions](/doc/decisions)

## Review

<!--
Reviewers can copy&check the following to their review.
Also the checklist above can be used.
But also the PR creator should check these points when getting a PR done:
-->

- [ ] I've tested the code
- [ ] I've read through the whole code
- [ ] Examples are well chosen and understandable
