### PR TITLE
Feature/802 create nextcloud shares on map creation

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -394,8 +394,8 @@ dependencies = [
  "jsonwebtoken",
  "log",
  "postgis_diesel",
+ "quick-xml",
  "reqwest",
- "roxmltree",
  "serde",
  "serde_json",
  "tokio",
@@ -1896,6 +1896,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,15 +2046,6 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
-]
-
-[[package]]
-name = "roxmltree"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f595a457b6b8c6cda66a48503e92ee8d19342f905948f29c383200ec9eb1d8"
-dependencies = [
- "xmlparser",
 ]
 
 [[package]]
@@ -3078,12 +3079,6 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "xmlparser"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
 
 [[package]]
 name = "yasna"

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -395,6 +395,7 @@ dependencies = [
  "log",
  "postgis_diesel",
  "reqwest",
+ "roxmltree",
  "serde",
  "serde_json",
  "tokio",
@@ -2038,6 +2039,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f595a457b6b8c6cda66a48503e92ee8d19342f905948f29c383200ec9eb1d8"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
 name = "rust-embed"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3068,6 +3078,12 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
 
 [[package]]
 name = "yasna"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -55,6 +55,7 @@ log = "0.4.17"
 env_logger = "0.10.0"
 futures = "0.3.28"
 image = { version = "0.24.6", default-features = false, features = ["png"] }
+roxmltree = "0.18.0"
 
 
 [dev-dependencies]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -55,7 +55,7 @@ log = "0.4.17"
 env_logger = "0.10.0"
 futures = "0.3.28"
 image = { version = "0.24.6", default-features = false, features = ["png"] }
-roxmltree = "0.18.0"
+quick-xml = { version = "0.30.0", features = ["serialize"]}
 
 
 [dev-dependencies]

--- a/backend/src/config/auth.rs
+++ b/backend/src/config/auth.rs
@@ -4,6 +4,7 @@ mod claims;
 pub mod jwks;
 pub mod middleware;
 pub mod user_info;
+pub mod user_token;
 
 use jsonwebtoken::jwk::JwkSet;
 use log::trace;

--- a/backend/src/config/auth/middleware.rs
+++ b/backend/src/config/auth/middleware.rs
@@ -5,7 +5,7 @@ use actix_web::dev::ServiceRequest;
 use actix_web_grants::permissions::AttachPermissions;
 use actix_web_httpauth::extractors::bearer::BearerAuth;
 
-use super::{claims::Claims, user_info::UserInfo};
+use super::{claims::Claims, user_info::UserInfo, user_token::UserToken};
 
 /// Validates JWTs in requests and sets user information as part of the request.
 ///
@@ -22,8 +22,11 @@ pub fn validator(
         Err(err) => return Err((err.into(), req)),
     };
 
+    let user_token = UserToken::from(credentials);
+
     req.extensions_mut().insert(user_info.clone());
     req.attach(user_info.scopes);
+    req.extensions_mut().insert(user_token.clone());
 
     Ok(req)
 }

--- a/backend/src/config/auth/user_token.rs
+++ b/backend/src/config/auth/user_token.rs
@@ -1,0 +1,47 @@
+//! Contains [`UserToken`] which stores the current user token.
+
+use actix_http::{HttpMessage, StatusCode};
+use actix_utils::future::{ready, Ready};
+use actix_web::FromRequest;
+use actix_web_httpauth::extractors::bearer::BearerAuth;
+use serde::Deserialize;
+
+use crate::error::ServiceError;
+
+/// User token.
+#[derive(Debug, Clone, Deserialize)]
+pub struct UserToken {
+    /// The current users token.
+    pub token: String,
+}
+
+impl From<&BearerAuth> for UserToken {
+    fn from(value: &BearerAuth) -> Self {
+        Self {
+            token: value.token().to_string(),
+        }
+    }
+}
+
+impl FromRequest for UserToken {
+    type Future = Ready<Result<Self, Self::Error>>;
+    type Error = ServiceError;
+
+    fn from_request(
+        req: &actix_web::HttpRequest,
+        _payload: &mut actix_http::Payload,
+    ) -> Self::Future {
+        let extensions = req.extensions();
+        ready({
+            extensions.get::<Self>().map_or_else(
+                || {
+                    Err(ServiceError::new(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        StatusCode::INTERNAL_SERVER_ERROR.to_string(),
+                    ))
+                },
+                |user_token| Ok(user_token.clone()),
+            )
+        })
+    }
+}

--- a/backend/src/controller/map.rs
+++ b/backend/src/controller/map.rs
@@ -86,9 +86,10 @@ pub async fn create(
     new_map_json: Json<NewMapDto>,
     user_info: UserInfo,
     app_data: Data<AppDataInner>,
-    user_token: UserToken
+    user_token: UserToken,
 ) -> Result<HttpResponse> {
-    let response = service::map::create(new_map_json.0, user_info.id, &app_data, user_token).await?;
+    let response =
+        service::map::create(new_map_json.0, user_info.id, &app_data, user_token).await?;
     Ok(HttpResponse::Created().json(response))
 }
 

--- a/backend/src/controller/map.rs
+++ b/backend/src/controller/map.rs
@@ -6,8 +6,10 @@ use actix_web::{
     web::{Data, Json, Path},
     HttpResponse, Result,
 };
+use actix_web_httpauth::extractors::bearer::BearerAuth;
 
 use crate::config::auth::user_info::UserInfo;
+use crate::config::auth::user_token::UserToken;
 use crate::config::data::AppDataInner;
 use crate::model::dto::{MapSearchParameters, PageParameters, UpdateMapDto};
 use crate::{model::dto::NewMapDto, service};
@@ -84,8 +86,9 @@ pub async fn create(
     new_map_json: Json<NewMapDto>,
     user_info: UserInfo,
     app_data: Data<AppDataInner>,
+    user_token: UserToken
 ) -> Result<HttpResponse> {
-    let response = service::map::create(new_map_json.0, user_info.id, &app_data).await?;
+    let response = service::map::create(new_map_json.0, user_info.id, &app_data, user_token).await?;
     Ok(HttpResponse::Created().json(response))
 }
 

--- a/backend/src/controller/map.rs
+++ b/backend/src/controller/map.rs
@@ -6,7 +6,6 @@ use actix_web::{
     web::{Data, Json, Path},
     HttpResponse, Result,
 };
-use actix_web_httpauth::extractors::bearer::BearerAuth;
 
 use crate::config::auth::user_info::UserInfo;
 use crate::config::auth::user_token::UserToken;

--- a/backend/src/model/dto.rs
+++ b/backend/src/model/dto.rs
@@ -250,7 +250,7 @@ pub struct MapDto {
 
 /// The information of a map necessary for its creation.
 #[typeshare]
-#[derive(Serialize, Deserialize, ToSchema)]
+#[derive(Serialize, Deserialize, ToSchema, Clone)]
 pub struct NewMapDto {
     /// The name of the map.
     pub name: String,

--- a/backend/src/model/enum/privacy_option.rs
+++ b/backend/src/model/enum/privacy_option.rs
@@ -7,7 +7,7 @@ use utoipa::ToSchema;
 
 /// Enum for map privacy setting options.
 #[typeshare]
-#[derive(Serialize, Deserialize, DbEnum, Debug, ToSchema, Clone)]
+#[derive(Serialize, Deserialize, DbEnum, PartialEq, Debug, ToSchema, Clone)]
 #[ExistingTypePath = "crate::schema::sql_types::PrivacyOption"]
 pub enum PrivacyOption {
     /// Data is private and only visible for owner or members, the data was explicitly shared with.

--- a/backend/src/service/map.rs
+++ b/backend/src/service/map.rs
@@ -322,7 +322,8 @@ pub async fn create(
                 reason: "Failed to share with PermaplanT circle!".to_string(),
             });
         }
-    }.await;
+    }
+    .await;
 
     Ok(result)
 }

--- a/backend/src/service/map.rs
+++ b/backend/src/service/map.rs
@@ -175,10 +175,10 @@ async fn create_nextcloud_circle(map_name: String, token: String) -> Result<Stri
     }
 }
 
-// Create a directory for map data in Nextcloud
-async fn create_map_dir(
+// Create a directory in Nextcloud
+async fn create_directory(
     user_id: Uuid,
-    map_name: String,
+    path: String,
     token: String,
 ) -> Result<(), ServiceError> {
     // Create a map directory in Nextcloud
@@ -186,7 +186,7 @@ async fn create_map_dir(
         "{}/remote.php/dav/files/{}/PermaplanT/{}",
         BASE_URL.to_owned(),
         user_id,
-        map_name.clone()
+        path.clone()
     );
 
     let client = reqwest::Client::new();
@@ -309,7 +309,9 @@ pub async fn create(
     // create Nextcloud circle with the map name
     let circle_id = create_nextcloud_circle(map_name.clone(), token.clone());
     // create a directory with the map name
-    create_map_dir(user_id, map_name.clone(), token.clone()).await?;
+    create_directory(user_id, map_name.clone(), token.clone()).await?;
+    // create a directory for the base layer within
+    create_directory(user_id, map_name.clone() + "/Base/", token.clone()).await?;
     share_directory(map_name.clone(), token.clone(), circle_id.await.unwrap()).await;
     //TODO: fetch id from public permaplant circle and share with it if public is checked
     let circle_id = find_circle("PermaplanT".to_owned(), token.clone());

--- a/backend/src/service/map.rs
+++ b/backend/src/service/map.rs
@@ -4,6 +4,7 @@ use actix_http::StatusCode;
 use actix_web::web::Data;
 use uuid::Uuid;
 
+use crate::config::auth::user_token::UserToken;
 use crate::config::data::AppDataInner;
 use crate::model::dto::{BaseLayerImageDto, MapSearchParameters, Page, UpdateMapDto};
 use crate::model::dto::{NewLayerDto, PageParameters};
@@ -52,6 +53,7 @@ pub async fn create(
     new_map: NewMapDto,
     user_id: Uuid,
     app_data: &Data<AppDataInner>,
+    user_token: UserToken,
 ) -> Result<MapDto, ServiceError> {
     let mut conn = app_data.pool.get().await?;
     let result = Map::create(new_map, user_id, &mut conn).await?;
@@ -81,6 +83,16 @@ pub async fn create(
             )
             .await?;
         }
+
+        // Create a map directory in Nextcloud
+        println!("--------------------------------");
+        println!("user token: {}", user_token.token);
+        println!("--------------------------------");
+
+
+
+        // Create a Nextcloud circle with the same name as the map
+        // Share the map directory with the circle
     }
 
     Ok(result)

--- a/backend/src/service/map.rs
+++ b/backend/src/service/map.rs
@@ -1,11 +1,7 @@
 //! Service layer for maps.
 
-use std::collections::HashMap;
-
-use actix_http::{Method, StatusCode};
+use actix_http::StatusCode;
 use actix_web::web::Data;
-use log::{info, log};
-use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::config::auth::user_token::UserToken;
@@ -14,6 +10,7 @@ use crate::model::dto::{BaseLayerImageDto, MapSearchParameters, Page, UpdateMapD
 use crate::model::dto::{NewLayerDto, PageParameters};
 use crate::model::entity::{BaseLayerImages, Layer};
 use crate::model::r#enum::layer_type::LayerType;
+use crate::model::r#enum::privacy_option::PrivacyOption;
 use crate::{
     error::ServiceError,
     model::{
@@ -22,10 +19,10 @@ use crate::{
     },
 };
 
+use super::nextcloud::setup_nextcloud_shares;
+
 /// Defines which layers should be created when a new map is created.
 const LAYER_TYPES: [LayerType; 2] = [LayerType::Base, LayerType::Plants];
-
-const BASE_URL: &str = "https://cloud.permaplant.net/";
 
 /// Search maps from the database.
 ///
@@ -51,219 +48,6 @@ pub async fn find_by_id(id: i32, app_data: &Data<AppDataInner>) -> Result<MapDto
     Ok(result)
 }
 
-fn extract_id_from_doc(doc: &str) -> String {
-    let res: CreateCircleResponse = quick_xml::de::from_str(doc).unwrap();
-    log::info!("{:?}", res);
-    res.data.id
-}
-
-fn extract_id_from_circle_search_response(doc: &str) -> String {
-    let res: FindCircleResponse = quick_xml::de::from_str(doc).unwrap();
-    log::info!("{:?}", res);
-    res.data.element.id.clone()
-}
-
-#[derive(Debug, Deserialize)]
-pub struct CircleData {
-    pub id: String,
-    pub name: String,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub struct FindCircleData {
-    pub element: FindCircleDataElement,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FindCircleDataElement {
-    pub id: String,
-    pub user_id: String,
-    pub user_type: i32,
-    pub display_name: String,
-    pub instance: String,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct CreateCircleResponse {
-    pub meta: Meta,
-    pub data: CircleData,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct Meta {
-    pub status: String,
-    pub statuscode: i32,
-    pub message: String,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub struct FindCircleResponse {
-    pub meta: Meta,
-    pub data: FindCircleData,
-}
-
-// Share a Nextcloud directory with a Nextcloud circle
-async fn share_directory(dir_name: String, token: String, circle_id: String) {
-    // Share the map directory with the circle
-    let mut share_options = HashMap::new();
-    share_options.insert("path", format!("/PermaplanT/{}", dir_name));
-    share_options.insert("shareType", String::from("7"));
-    share_options.insert("permissions", String::from("31"));
-    share_options.insert("shareWith", circle_id);
-
-    info!("{:?}", share_options);
-
-    // For public maps share the map directory with PermaplanT circle
-    let url = BASE_URL.to_owned() + "ocs/v2.php/apps/files_sharing/api/v1/shares";
-    let client = reqwest::Client::new();
-    let res = client
-        .post(url)
-        .json(&share_options)
-        .header("OCS-APIRequest", "true")
-        .header("Content-Type", "application/json")
-        .header("Authorization", format!("Bearer {}", token))
-        .send()
-        .await;
-    log::info!("Share directory with PermaplanT circle");
-    match res {
-        Ok(response) => {
-            log::info!("Share creation result: {}", response.status());
-        }
-        Err(e) => log::error!("Share creation failed! {}", e),
-    }
-    log::info!("--------------------------");
-}
-
-// Create a Nextlcoud circle and return id
-async fn create_nextcloud_circle(map_name: String, token: String) -> Result<String, ServiceError> {
-    // Create a Nextcloud circle with the same name as the map
-    let mut map = HashMap::new();
-    map.insert("name", map_name.clone());
-    map.insert("personal", String::from("false"));
-    map.insert("local", String::from("false"));
-
-    let client = reqwest::Client::new();
-
-    let url = BASE_URL.to_owned() + "ocs/v2.php/apps/circles/circles";
-    let res = client
-        .post(url)
-        .json(&map)
-        .header("OCS-APIRequest", "true")
-        .header("Content-Type", "application/json")
-        .header("Authorization", format!("Bearer {}", token))
-        .send()
-        .await;
-    log::info!("Circle creation Result");
-    log::info!("Token");
-    log::info!("{}", token);
-    match res {
-        Ok(response) => {
-            log::info!("Circle creation result: {}", response.status());
-            let data = response.text().await.unwrap();
-            Ok(extract_id_from_doc(&data))
-        }
-        Err(e) => {
-            log::error!("Circle creation failed! {}", e);
-            return Err(ServiceError {
-                status_code: StatusCode::INTERNAL_SERVER_ERROR,
-                reason: "Circle creation failed!".to_string(),
-            });
-        }
-    }
-}
-
-// Create a directory in Nextcloud
-async fn create_directory(
-    user_id: Uuid,
-    path: String,
-    token: String,
-) -> Result<(), ServiceError> {
-    // Create a map directory in Nextcloud
-    let url = format!(
-        "{}/remote.php/dav/files/{}/PermaplanT/{}",
-        BASE_URL.to_owned(),
-        user_id,
-        path.clone()
-    );
-
-    let client = reqwest::Client::new();
-    let method = Method::from_bytes(b"MKCOL");
-    let method = match method {
-        Ok(method) => method,
-        Err(_) => {
-            return Err(ServiceError {
-                status_code: StatusCode::INTERNAL_SERVER_ERROR,
-                reason: "invalid method".to_string(),
-            })
-        }
-    };
-    log::info!("{:?}", method);
-    let res = client
-        .request(method, url)
-        .header("Content-Type", "application/json")
-        .header("Authorization", format!("Bearer {}", token))
-        .send()
-        .await;
-
-    log::info!("--------------------------");
-    log::info!("Directory creation Result");
-    match res {
-        Ok(response) => {
-            log::info!("Map directory creation result: {}", response.status());
-        }
-        Err(e) => {
-            log::info!("Map directory creation failed! {}", e);
-            return Err(ServiceError {
-                status_code: StatusCode::INTERNAL_SERVER_ERROR,
-                reason: "Map directory creation failed".to_string(),
-            });
-        }
-    }
-    log::info!("--------------------------");
-    Ok(())
-}
-
-// Find a Nextcloud circle by name
-pub async fn find_circle(name: String, token: String) -> Result<String, ServiceError> {
-    let client = reqwest::Client::new();
-    let url = format!(
-        "{}ocs/v2.php/apps/circles/search?term={}",
-        BASE_URL.to_owned(),
-        name
-    );
-    let res = client
-        .get(url)
-        .header("Content-Type", "application/json")
-        .header("Authorization", format!("Bearer {}", token))
-        .send()
-        .await;
-
-    log::info!("--------------------------");
-    log::info!("Directory creation Result");
-    match res {
-        Ok(response) => {
-            log::info!("Find circle result: {}", response.status());
-            match response.text().await {
-                Ok(v) => Ok(extract_id_from_circle_search_response(&v)),
-                Err(_) => Err(ServiceError {
-                    status_code: StatusCode::INTERNAL_SERVER_ERROR,
-                    reason: "Search circle failed".to_string(),
-                }),
-            }
-        }
-        Err(e) => {
-            log::info!("Search Circle failed! {}", e);
-            return Err(ServiceError {
-                status_code: StatusCode::INTERNAL_SERVER_ERROR,
-                reason: "Search circle failed".to_string(),
-            });
-        }
-    }
-}
-
 /// Create a new map in the database.
 ///
 /// # Errors
@@ -274,8 +58,17 @@ pub async fn create(
     app_data: &Data<AppDataInner>,
     user_token: UserToken,
 ) -> Result<MapDto, ServiceError> {
+    setup_nextcloud_shares(
+        user_id,
+        &new_map.name,
+        &user_token.token,
+        new_map.privacy == PrivacyOption::Public,
+    )
+    .await?;
+
     let mut conn = app_data.pool.get().await?;
-    let result = Map::create(new_map.clone(), user_id, &mut conn).await?;
+    let result = Map::create(new_map, user_id, &mut conn).await?;
+
     for layer_type in &LAYER_TYPES {
         let new_layer = NewLayerDto {
             map_id: result.id,
@@ -303,29 +96,6 @@ pub async fn create(
             .await?;
         }
     }
-    let token = user_token.token.clone();
-    let map_name = new_map.name.clone();
-
-    // create Nextcloud circle with the map name
-    let circle_id = create_nextcloud_circle(map_name.clone(), token.clone());
-    // create a directory with the map name
-    create_directory(user_id, map_name.clone(), token.clone()).await?;
-    // create a directory for the base layer within
-    create_directory(user_id, map_name.clone() + "/Base/", token.clone()).await?;
-    share_directory(map_name.clone(), token.clone(), circle_id.await.unwrap()).await;
-    //TODO: fetch id from public permaplant circle and share with it if public is checked
-    let circle_id = find_circle("PermaplanT".to_owned(), token.clone());
-    match circle_id.await {
-        Ok(id) => share_directory(map_name.clone(), token.clone(), id),
-        Err(e) => {
-            log::info!("Failed to share with PermaplanT circle! {}", e);
-            return Err(ServiceError {
-                status_code: StatusCode::INTERNAL_SERVER_ERROR,
-                reason: "Failed to share with PermaplanT circle!".to_string(),
-            });
-        }
-    }
-    .await;
 
     Ok(result)
 }

--- a/backend/src/service/map.rs
+++ b/backend/src/service/map.rs
@@ -226,6 +226,7 @@ async fn create_map_dir(
     Ok(())
 }
 
+// Find a Nextcloud circle by name
 pub async fn find_circle(name: String, token: String) -> Result<String, ServiceError> {
     let client = reqwest::Client::new();
     let url = format!(

--- a/backend/src/service/mod.rs
+++ b/backend/src/service/mod.rs
@@ -5,6 +5,7 @@ pub mod blossoms;
 pub mod guided_tours;
 pub mod layer;
 pub mod map;
+pub mod nextcloud;
 pub mod plant_layer;
 pub mod plantings;
 pub mod plants;

--- a/backend/src/service/nextcloud.rs
+++ b/backend/src/service/nextcloud.rs
@@ -1,0 +1,284 @@
+use crate::error::ServiceError;
+use actix_http::{Method, StatusCode};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+const BASE_URL: &str = "https://cloud.permaplant.net/";
+
+#[derive(Debug, Deserialize)]
+pub struct CreateCircleResponse {
+    pub meta: Meta,
+    pub data: CircleData,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Meta {
+    pub status: String,
+    pub statuscode: i32,
+    pub message: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CircleData {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct FindCircleData {
+    pub element: FindCircleDataElement,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FindCircleDataElement {
+    pub id: String,
+    pub user_id: String,
+    pub user_type: i32,
+    pub display_name: String,
+    pub instance: String,
+}
+
+fn extract_id_from_doc(doc: &str) -> String {
+    let res: CreateCircleResponse = quick_xml::de::from_str(doc).unwrap();
+    log::debug!("{:?}", res);
+    res.data.id
+}
+
+fn extract_id_from_circle_search_response(doc: &str) -> String {
+    let res: FindCircleResponse = quick_xml::de::from_str(doc).unwrap();
+    log::debug!("{:?}", res);
+    res.data.element.id.clone()
+}
+
+pub async fn setup_nextcloud_shares(
+    user_id: Uuid,
+    map_name: &str,
+    token: &str,
+    _should_share_publicly: bool,
+) -> Result<(), ServiceError> {
+    // create Nextcloud circle with the map name
+    let circle_id = create_nextcloud_circle(map_name, token).await?;
+    // create a directory with the map name
+    create_directory(user_id, map_name, token).await?;
+    // create a directory for the base layer within
+    create_directory(user_id, &format!("{}/Base/", map_name), token).await?;
+    share_directory(map_name, token, circle_id).await?;
+
+    // FIXME: nextcloud returns 500 error
+    // if should_share_publicly {
+    //     let public_circle_id = find_circle("PermaplanT", token).await?;
+    //     share_directory(map_name, token, public_circle_id).await?;
+    // }
+
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct FindCircleResponse {
+    pub meta: Meta,
+    pub data: FindCircleData,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct NextcloudSharedOptionsDto {
+    path: String,
+    share_type: i16,
+    permissions: i16,
+    share_with: String,
+}
+
+// Share a Nextcloud directory with a Nextcloud circle
+async fn share_directory(
+    dir_name: &str,
+    token: &str,
+    circle_id: String,
+) -> Result<(), ServiceError> {
+    // Share the map directory with the circle
+    let share_options = NextcloudSharedOptionsDto {
+        path: format!("/PermaplanT/{}", dir_name),
+        share_type: 7,
+        permissions: 31,
+        share_with: circle_id.to_owned(),
+    };
+
+    log::debug!("Sharing directory");
+    log::debug!("{:?}", share_options);
+
+    // For public maps share the map directory with PermaplanT circle
+    let url = BASE_URL.to_owned() + "ocs/v2.php/apps/files_sharing/api/v1/shares";
+    let client = reqwest::Client::new();
+    let res = client
+        .post(url)
+        .json(&share_options)
+        .header("OCS-APIRequest", "true")
+        .header("Content-Type", "application/json")
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await;
+
+    match res {
+        Ok(response) => {
+            let status_code = response.status();
+            let response_text = response.text().await.expect("Could not get response text");
+
+            match status_code {
+                StatusCode::OK => Ok(()),
+                _ => {
+                    log::error!("Share creation failed! {}", response_text);
+                    Err(ServiceError {
+                        status_code: StatusCode::BAD_REQUEST,
+                        reason: "Share creation failed!".to_string(),
+                    })
+                }
+            }
+        }
+        Err(e) => {
+            log::error!("Share creation failed! {}", e);
+            Err(ServiceError {
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                reason: "Share creation failed!".to_string(),
+            })
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct CreateNextcloudCircleDto {
+    name: String,
+    personal: bool,
+    local: bool,
+}
+
+// Create a Nextcloud circle and return id
+async fn create_nextcloud_circle(map_name: &str, token: &str) -> Result<String, ServiceError> {
+    // TODO: validate map_name to match nextcloud requirements for circle names
+
+    // Create a Nextcloud circle with the same name as the map
+    let payload = CreateNextcloudCircleDto {
+        name: map_name.to_owned(),
+        personal: false,
+        local: false,
+    };
+
+    let client = reqwest::Client::new();
+
+    let url = BASE_URL.to_owned() + "ocs/v2.php/apps/circles/circles";
+    let res = client
+        .post(url)
+        .json(&payload)
+        .header("OCS-APIRequest", "true")
+        .header("Content-Type", "application/json")
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await;
+    log::info!("Token: {}", token);
+    match res {
+        Ok(response) => {
+            let status_code = response.status();
+            let response_text = response.text().await.expect("Could not get response text");
+            log::debug!("Circle creation result: {}", status_code);
+
+            match status_code {
+                StatusCode::OK => Ok(extract_id_from_doc(&response_text)),
+                _ => {
+                    log::error!("Circle creation failed! {}", response_text);
+                    Err(ServiceError {
+                        status_code: StatusCode::BAD_REQUEST,
+                        reason: "Circle creation failed!".to_string(),
+                    })
+                }
+            }
+        }
+        Err(e) => {
+            log::error!("Circle creation failed! {}", e);
+            Err(ServiceError {
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                reason: "Circle creation failed!".to_string(),
+            })
+        }
+    }
+}
+
+// Create a directory in Nextcloud
+async fn create_directory(user_id: Uuid, path: &str, token: &str) -> Result<(), ServiceError> {
+    // Create a map directory in Nextcloud
+    let url = format!(
+        "{}/remote.php/dav/files/{}/PermaplanT/{}",
+        BASE_URL.to_owned(),
+        user_id,
+        path.clone()
+    );
+
+    let client = reqwest::Client::new();
+    let method = Method::from_bytes(b"MKCOL");
+    let method = match method {
+        Ok(method) => method,
+        Err(e) => {
+            log::error!("Circle creation failed! {}", e);
+            return Err(ServiceError {
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                reason: "invalid method".to_string(),
+            });
+        }
+    };
+    let res = client
+        .request(method, url)
+        .header("Content-Type", "application/json")
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await;
+
+    match res {
+        Ok(response) => {
+            log::debug!("Map directory creation result: {}", response.status());
+            Ok(())
+        }
+        Err(e) => {
+            log::error!("Map directory creation failed! {}", e);
+            Err(ServiceError {
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                reason: "Map directory creation failed".to_string(),
+            })
+        }
+    }
+}
+
+// Find a Nextcloud circle by name
+pub async fn find_circle(name: &str, token: &str) -> Result<String, ServiceError> {
+    let client = reqwest::Client::new();
+    let url = format!(
+        "{}ocs/v2.php/apps/circles/search?term={}",
+        BASE_URL.to_owned(),
+        name
+    );
+    let res = client
+        .get(url)
+        .header("Content-Type", "application/json")
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await;
+
+    match res {
+        Ok(response) => {
+            log::info!("Find circle result: {}", response.status());
+            match response.text().await {
+                Ok(v) => Ok(extract_id_from_circle_search_response(&v)),
+                Err(_) => Err(ServiceError {
+                    status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                    reason: "Search circle failed".to_string(),
+                }),
+            }
+        }
+        Err(e) => {
+            log::info!("Search Circle failed! {}", e);
+            Err(ServiceError {
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                reason: "Search circle failed".to_string(),
+            })
+        }
+    }
+}

--- a/frontend/src/features/map_planning/layers/base/components/BaseLayerRightToolbar.tsx
+++ b/frontend/src/features/map_planning/layers/base/components/BaseLayerRightToolbar.tsx
@@ -8,6 +8,10 @@ import useDebouncedValue from '@/hooks/useDebouncedValue';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FileStat } from 'webdav';
+import { useMapId } from '@/features/map_planning/hooks/useMapId';
+import { baseApiUrl } from '@/config';
+import { useQuery } from '@tanstack/react-query';
+import { findMapById } from '@/features/maps/api/findMapById';
 
 class ValidationError extends Error {
   constructor(msg: string) {
@@ -49,6 +53,13 @@ export const BaseLayerRightToolbar = () => {
   const executeAction = useMapStore((state) => state.executeAction);
   // const activateMeasurement = useMapStore((state) => state.baseLayerActivateMeasurement);
   // const deactivateMeasurement = useMapStore((state) => state.baseLayerDeactivateMeasurement);
+
+  const mapId = useMapId();
+  const { data: mapData } = useQuery([mapId], {
+    queryFn: () => findMapById(mapId),
+  });
+  console.log("current map:", mapData)
+
 
   const { t } = useTranslation(['common', 'baseLayerForm']);
 
@@ -178,10 +189,10 @@ export const BaseLayerRightToolbar = () => {
         onCancel={function (): void {
           setShowFileSelector(false);
         }}
-        path={'/Photos/'}
+        path={"/PermaplanT/" + mapData?.name + "/Base/"}
         onSelect={function (item: FileStat): void {
           const scale = baseLayerState.scale;
-          const path = '/Photos/' + item.basename;
+          const path = "/PermaplanT/" + mapData?.name + "/Base/" + item.basename;
           const rotation = baseLayerState.rotation;
           executeAction(
             new UpdateBaseLayerAction({

--- a/frontend/src/features/maps/api/createMap.ts
+++ b/frontend/src/features/maps/api/createMap.ts
@@ -4,7 +4,7 @@ import { createAPI } from '@/config/axios';
 export async function createMap(map: NewMapDto) {
   const http = createAPI();
   try {
-    const response = await http.post<MapDto>('/api/maps', map);
+    const response = await http.post<MapDto>('/api/maps', map, { timeout: 0 });
     return response.data;
   } catch (error) {
     throw error as Error;


### PR DESCRIPTION
<!--
Check relevant points but **please do not remove entries**.
-->

This PR extends the map creation endpoint by creating a Nextcloud directory, Nextcloud circle and sharing the directory with the circle.

Currently the request is not transactional which means that when one of the Nextcloud requests or the database request fails, the data sources are left in an inconsistent state.

Furthermore the frontend can be refactored to make use of react query mutations.
As well as user indications like a loading spinner would be very useful.

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [ ] I added a line to [/doc/CHANGELOG.md](/doc/CHANGELOG.md)
- [ ] The PR is rebased with current master.
- [ ] Details of what you changed are in commit messages.
- [ ] References to issues, e.g. `close #X`, are in the commit messages.
- [ ] The buildserver is happy.

<!--
If you have any troubles fulfilling these criteria, please write about the trouble as comment in the PR.
We will help you, but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For documentation fixes, spell checking, and similar none of these points below need to be checked.
Otherwise please check these points when getting a PR done:
-->

- [ ] I have installed and I am using [pre-commit hooks](../doc/contrib/README.md#Hooks)
- [ ] I fully described what my PR does in the documentation
      (not in the PR description)
- [ ] I fixed all affected documentation
- [ ] I fixed the introduction tour
- [ ] I wrote migrations in a way that they are compatible with already present data
- [ ] I fixed all affected decisions
- [ ] I added unit tests for my code
- [ ] I added code comments, logging, and assertions as appropriate
- [ ] I translated all strings visible to the user
- [ ] I mentioned [every code or binary](https://github.com/ElektraInitiative/PermaplanT/blob/master/.reuse/dep5) not directly written or done by me in [reuse syntax](https://reuse.software/)
- [ ] I created left-over issues for things that are still to be done
- [ ] Code is conforming to [our Architecture](/doc/architecture)
- [ ] Code is conforming to [our Guidelines](/doc/guidelines)
      (exceptions are documented)
- [ ] Code is consistent to [our Design Decisions](/doc/decisions)

## Review

<!--
Reviewers can copy&check the following to their review.
Also the checklist above can be used.
But also the PR creator should check these points when getting a PR done:
-->

- [ ] I've tested the code
- [ ] I've read through the whole code
- [ ] Examples are well chosen and understandable
