### PR TITLE
Add 200ms timeout before clicking on canvas

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -63,7 +63,7 @@ Syntax: `- short text describing the change _(Your Name)_`
 - _()_
 - Fix textarea not allowing more than one line of text _(Moritz)_
 - _()_
-- _()_
+- E2E: Increase click on canvas robustness _(4ydan)_
 - Fix cargo deny check _(4ydan)_
 - Improve Makefile #681 _(4ydan)_
 - CI: Tag docker images #931 _(4ydan)_

--- a/e2e/pages/maps/planting.py
+++ b/e2e/pages/maps/planting.py
@@ -113,12 +113,13 @@ class MapPlantingPage(AbstractPage):
         self._page.get_by_test_id(plant_name + "-plant-search-result").click()
 
     def click_on_canvas_middle(self):
+        self._page.wait_for_timeout(200)
         """Clicks in the middle of the canvas with a 300ms delay."""
         box = self._canvas.bounding_box()
         self._page.mouse.click(
             box["x"] + box["width"] / 2, box["y"] + box["height"] / 2
         )
-        self._page.wait_for_timeout(300)
+        self._page.wait_for_timeout(200)
 
     def drag_select_box_over_canvas(self):
         """Drags a select box over 75% of the canvas from top left to bottom right"""
@@ -142,21 +143,6 @@ class MapPlantingPage(AbstractPage):
             box["x"] + box["width"] / 4, box["y"] + box["height"] / 4
         )
         self._page.wait_for_timeout(300)
-
-    def drag_select_box_over_canvas(self):
-        """Drags a select box over 75% of the canvas from top left to bottom right"""
-        box = self._canvas.bounding_box()
-        x = box["x"]
-        y = box["y"]
-        width = box["width"]
-        height = box["height"]
-        self._page.mouse.move(x + width / 4, y + height / 4)
-        self._page.mouse.down()
-        self._page.mouse.move(x + (width / 4) * 3, y + (height / 4) * 3)
-        # https://playwright.dev/docs/input#drag-and-drop:~:text=()%3B-,NOTE,-If%20your%20page
-        # I dont know why, but it works only with a second mouse.move()
-        self._page.mouse.move(x + (width / 4) * 3, y + (height / 4) * 3)
-        self._page.mouse.up()
 
     def click_delete(self):
         """Deletes a planting by clicks on the delete button."""


### PR DESCRIPTION
So there is no regression on master, I put a wait before clicking on the canvas. I think the issue was timing related. The icon didnt reappear fast enough on the canvas, and the click went into nothing.

Also this PR removes some duplicate code, that was introduced in a merge conflict.

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [x] I added a line to [changelog.md](/doc/changelog.md)
- [x] The PR is rebased with current master.
- [x] Details of what you changed are in commit messages.
- [x] References to issues, e.g. `close #X`, are in the commit messages and changelog.
- [x] The buildserver is happy.

<!--
If you have any troubles fulfilling these criteria, please write about the trouble as comment in the PR.
We will help you, but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For documentation fixes, spell checking, and similar none of these points below need to be checked.
Otherwise please check these points when getting a PR done:
-->

- [ ] I have installed and I am using [pre-commit hooks](../doc/contrib/README.md#Hooks)
- [ ] I fully described what my PR does in the documentation
- [ ] I fixed all affected documentation
- [ ] I fixed the introduction tour
- [ ] I wrote migrations in a way that they are compatible with already present data
- [ ] I fixed all affected decisions
- [ ] I added automated tests or a [manual test protocol](../doc/tests/manual/protocol.md)
- [ ] I added code comments, logging, and assertions as appropriate
- [ ] I translated all strings visible to the user
- [ ] I mentioned [every code or binary](https://github.com/ElektraInitiative/PermaplanT/blob/master/.reuse/dep5) not directly written or done by me in [reuse syntax](https://reuse.software/)
- [ ] I created left-over issues for things that are still to be done
- [ ] Code is conforming to [our Architecture](/doc/architecture)
- [ ] Code is conforming to [our Guidelines](/doc/guidelines)
- [ ] Code is consistent to [our Design Decisions](/doc/decisions)
- [ ] Exceptions to any guidelines are documented

## Review

<!--
Reviewers can copy&check the following to their review.
Also the checklist above can be used.
But also the PR creator should check these points when getting a PR done:
-->

- [ ] I've tested the code
- [ ] I've read through the whole code
- [ ] I've read through the whole documentation
- [ ] I've checked conformity to guidelines
