### PR TITLE
Disable e2e in master

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -302,11 +302,11 @@ lock("${env.NODE_NAME}-exclusive") {
         node('docker') {
             node_info()
             checkout scm
-            if (env.BRANCH_NAME != 'master') {
-                echo "Skipping E2E Tests for branch ${env.BRANCH_NAME}"
+            def target = 'https://pr.permaplant.net'
+            if (env.BRANCH_NAME == 'master') {
+                echo 'Skipping E2E Tests for master'
                 return
             }
-            def target = 'https://pr.permaplant.net'
             try {
                 docker.build('permaplant-e2e:ci', './e2e').inside('-e E2E_URL=' + target) {
                     wait_for_pr_db()

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -302,10 +302,11 @@ lock("${env.NODE_NAME}-exclusive") {
         node('docker') {
             node_info()
             checkout scm
-            def target = 'https://pr.permaplant.net'
-            if (env.BRANCH_NAME == 'master') {
-                target = 'https://dev.permaplant.net'
+            if (env.BRANCH_NAME != 'master') {
+                echo "Skipping E2E Tests for branch ${env.BRANCH_NAME}"
+                return
             }
+            def target = 'https://pr.permaplant.net'
             try {
                 docker.build('permaplant-e2e:ci', './e2e').inside('-e E2E_URL=' + target) {
                     wait_for_pr_db()

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -59,7 +59,7 @@ Syntax: `- short text describing the change _(Your Name)_`
 - _()_
 - _()_
 - _()_
-- _()_
+- CI: disable E2E tests in master #1055 _(4ydan)_
 - _()_
 - _()_
 - _()_


### PR DESCRIPTION
Disables e2e tests on master branch until we find a solution to clean up the database.
Closes #1003 

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [ ] I added a line to [changelog.md](/doc/changelog.md)
- [ ] The PR is rebased with current master.
- [ ] Details of what you changed are in commit messages.
- [ ] References to issues, e.g. `close #X`, are in the commit messages and changelog.
- [ ] The buildserver is happy.

<!--
If you have any troubles fulfilling these criteria, please write about the trouble as comment in the PR.
We will help you, but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For documentation fixes, spell checking, and similar none of these points below need to be checked.
Otherwise please check these points when getting a PR done:
-->

- [ ] I have installed and I am using [pre-commit hooks](../doc/contrib/README.md#Hooks)
- [ ] I fully described what my PR does in the documentation
- [ ] I fixed all affected documentation
- [ ] I fixed the introduction tour
- [ ] I wrote migrations in a way that they are compatible with already present data
- [ ] I fixed all affected decisions
- [ ] I added automated tests or a [manual test protocol](../doc/tests/manual/protocol.md)
- [ ] I added code comments, logging, and assertions as appropriate
- [ ] I translated all strings visible to the user
- [ ] I mentioned [every code or binary](https://github.com/ElektraInitiative/PermaplanT/blob/master/.reuse/dep5) not directly written or done by me in [reuse syntax](https://reuse.software/)
- [ ] I created left-over issues for things that are still to be done
- [ ] Code is conforming to [our Architecture](/doc/architecture)
- [ ] Code is conforming to [our Guidelines](/doc/guidelines)
- [ ] Code is consistent to [our Design Decisions](/doc/decisions)
- [ ] Exceptions to any guidelines are documented

## Review

<!--
Reviewers can copy&check the following to their review.
Also the checklist above can be used.
But also the PR creator should check these points when getting a PR done:
-->

- [ ] I've tested the code
- [ ] I've read through the whole code
- [ ] I've read through the whole documentation
- [ ] I've checked conformity to guidelines
