### PR TITLE
Fix E2E planting cursor tests

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -60,7 +60,7 @@ Syntax: `- short text describing the change _(Your Name)_`
 - _()_
 - _()_
 - _()_
-- _()_
+- E2E: fix planting cursor tests _(4ydan & absurd-turtle)_
 - _()_
 - _()_
 - _()_

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -97,6 +97,10 @@ If any of the below mentioned variables are not set, the tests will fallback to 
 
   The password to login to permaplant.
 
+- `BROWSER_LOGS` (default: not set)
+
+  Writes console logs to console_logs.txt
+
 ### Project env variables
 
 Furthermore following variables are expected to be set in your environment and required by `clean_db.py`:

--- a/e2e/pages/abstract_page.py
+++ b/e2e/pages/abstract_page.py
@@ -1,8 +1,16 @@
 import re
+import os
 import time
 from abc import ABC
 from e2e.pages.constants import E2E_TIMEOUT
 from playwright.sync_api import Page, expect
+
+
+def log_errors(msg):
+    file1 = open("console_logs.txt", "a")  # append mode
+    for arg in msg.args:
+        file1.write(f"{arg.json_value()}\n")
+        file1.flush()
 
 
 class AbstractPage(ABC):
@@ -24,6 +32,10 @@ class AbstractPage(ABC):
         )
         self.dont_load_images_except_birdie()
         self._page.set_default_timeout(timeout=E2E_TIMEOUT)
+
+        if "BROWSER_LOGS" in os.environ:
+            self._page.on("console", log_errors)
+
         expect.set_options(timeout=E2E_TIMEOUT)
         response = self._page.goto(self.URL)
         assert response.status == 200

--- a/e2e/pages/maps/planting.py
+++ b/e2e/pages/maps/planting.py
@@ -153,6 +153,7 @@ class MapPlantingPage(AbstractPage):
         """Clicks in the middle of the canvas with a 300ms delay."""
         time.sleep(1)
         box = self._canvas.bounding_box()
+        self._page.mouse.move(box["x"] + box["width"] / 2, box["y"] + box["height"] / 2)
         self._page.mouse.click(
             box["x"] + box["width"] / 2, box["y"] + box["height"] / 2
         )
@@ -288,7 +289,6 @@ class MapPlantingPage(AbstractPage):
         by clicking in the middle of the canvas
         and making sure the delete button is not visible.
         """
-
         self.click_on_canvas_middle()
         expect(self._delete_plant_button).not_to_be_visible()
 

--- a/frontend/src/features/map_planning/layers/plant/PlantsLayer.tsx
+++ b/frontend/src/features/map_planning/layers/plant/PlantsLayer.tsx
@@ -5,7 +5,7 @@ import { SELECTION_RECTANGLE_NAME } from '../../utils/ShapesSelection';
 import { isPlantLayerActive } from '../../utils/layer-utils';
 import { isPlacementModeActive } from '../../utils/planting-utils';
 import { CreatePlantAction, MovePlantAction, TransformPlantAction } from './actions';
-// import { PlantCursor } from './components/PlantCursor';
+import { PlantCursor } from './components/PlantCursor';
 import { PlantLayerRelationsOverlay } from './components/PlantLayerRelationsOverlay';
 import { PlantingElement } from './components/PlantingElement';
 import { useDeleteSelectedPlantings } from './hooks/useDeleteSelectedPlantings';
@@ -309,9 +309,9 @@ function PlantsLayer(props: PlantsLayerProps) {
         ))}
         {plants.map((o) => showPlantLabels && <PlantLabel planting={o} key={o.id} />)}
       </Layer>
-      {/* <Layer>
+      <Layer>
         <PlantCursor />
-      </Layer> */}
+      </Layer>
     </>
   );
 }


### PR DESCRIPTION
Closes #1083
Also introduces a new flag for writing console logs to a file.

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [x] I added a line to [changelog.md](/doc/changelog.md)
- [x] The PR is rebased with current master.
- [x] Details of what you changed are in commit messages.
- [x] References to issues, e.g. `close #X`, are in the commit messages and changelog.
- [ ] The buildserver is happy.

<!--
If you have any troubles fulfilling these criteria, please write about the trouble as comment in the PR.
We will help you, but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For documentation fixes, spell checking, and similar none of these points below need to be checked.
Otherwise please check these points when getting a PR done:
-->

- [ ] I have installed and I am using [pre-commit hooks](../doc/contrib/README.md#Hooks)
- [ ] I fully described what my PR does in the documentation
- [ ] I fixed all affected documentation
- [ ] I fixed the introduction tour
- [ ] I wrote migrations in a way that they are compatible with already present data
- [ ] I fixed all affected decisions
- [ ] I added automated tests or a [manual test protocol](../doc/tests/manual/protocol.md)
- [ ] I added code comments, logging, and assertions as appropriate
- [ ] I translated all strings visible to the user
- [ ] I mentioned [every code or binary](https://github.com/ElektraInitiative/PermaplanT/blob/master/.reuse/dep5) not directly written or done by me in [reuse syntax](https://reuse.software/)
- [ ] I created left-over issues for things that are still to be done
- [ ] Code is conforming to [our Architecture](/doc/architecture)
- [ ] Code is conforming to [our Guidelines](/doc/guidelines)
- [ ] Code is consistent to [our Design Decisions](/doc/decisions)
- [ ] Exceptions to any guidelines are documented

## Review

<!--
Reviewers can copy&check the following to their review.
Also the checklist above can be used.
But also the PR creator should check these points when getting a PR done:
-->

- [ ] I've tested the code
- [ ] I've read through the whole code
- [ ] I've read through the whole documentation
- [ ] I've checked conformity to guidelines
